### PR TITLE
Add domain models specification (002-domain-models)

### DIFF
--- a/specs/002-domain-models/checklists/requirements.md
+++ b/specs/002-domain-models/checklists/requirements.md
@@ -34,6 +34,17 @@
 - 本仕様は P0（全仕様の共通基盤）であり、003〜007 すべてが依存する
 - 出力スキーマの具体的なフィールド構成は 003-agent-definition の策定時に最終確定される（Assumptions に記載済み）
 - 親仕様 FR-004（出力スキーマによる型検証）の「スキーマ定義」部分を本仕様が担当し、「実行時バリデーション」は 005-review-engine が担当する
+- Assumptions における pydantic-ai への言及はアーキテクチャ制約としての技術記述であり、実装詳細ではない
 - 全項目パス: 2026-02-06 初回バリデーション
 - clarify 実施: 2026-02-06（2件の質問で AgentResult ステータスパターン・出力スキーマ共通ベースモデルを確定）
-- pydantic-ai アーキテクチャ制約を Clarifications・Assumptions に追記済み
+- PR #2 レビュー反映: 2026-02-06（Important 5件 + Suggestion 8件を全件対応）
+  - AgentResult を判別共用体（Discriminated Union）に変更
+  - FileLocation 型を導入し ReviewIssue のファイル位置の依存関係を型で表現
+  - FR-DM-008 に終了コード 3・4 の責務境界を明記
+  - FR-DM-010 の正規形を PascalCase と明記
+  - FR-DM-011 を Key Entities と統一
+  - SC-DM-006 を測定可能な表現に変更
+  - ReviewReport の issues_by_severity を計算導出と明記
+  - コスト情報をオプショナルに変更
+  - BaseAgentOutput の summary 再検討を Assumptions に記載
+  - README.md の状態更新・スキーマ名統一

--- a/specs/002-domain-models/spec.md
+++ b/specs/002-domain-models/spec.md
@@ -15,14 +15,14 @@
 - README.md の「スキーマの所属境界」に基づき、SCHEMA_REGISTRY と各エージェントの出力スキーマはすべて 002-domain-models に含める。出力フォーマット（007）はフォーマッター・ストレージのみを担当する
 - Severity のマッピング（重大度の定義と対応する終了コード）は 002 で定義する
 - Q: ドメインモデルの実装技術に制約はあるか？ → A: エージェント実行基盤として pydantic-ai を採用しており、`result_type` による構造化出力制御に Pydantic モデルを必要とする。このアーキテクチャ制約により、ドメインモデル・出力スキーマは Pydantic モデルとして実装される
-- Q: AgentResult のステータス（成功/エラー/タイムアウト）をどのパターンで表現するか？ → A: ステータス列挙型（success/error/timeout）＋ 状態ごとのオプショナルフィールドで表現する
-- Q: 6種の出力スキーマに共通ベースモデルを設けるか？ → A: 共通ベースモデル（サマリーテキスト・ReviewIssue リスト）を定義し、全スキーマが継承する。ReviewReport への集約時に共通インターフェースでアクセスでき、新スキーマ追加時も一貫性が保証される
+- Q: AgentResult のステータス（成功/エラー/タイムアウト）をどのパターンで表現するか？ → A: 判別共用体（Discriminated Union）パターンを採用する。成功（AgentSuccess）・エラー（AgentError）・タイムアウト（AgentTimeout）を個別モデルとして定義し、判別キー（status フィールドの固定値）で型を一意に特定する。AgentResult はこれら3型の Union 型とする。これにより不可能な状態を型レベルで排除し、パターンマッチングによる型安全な分岐を可能にする
+- Q: 6種の出力スキーマに共通ベースモデルを設けるか？ → A: 共通ベースモデル（ReviewIssue リスト）を定義し、全スキーマが継承する。ReviewReport への集約時に共通インターフェースでアクセスでき、新スキーマ追加時も一貫性が保証される
 
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - 共通ドメインモデルによるエージェント結果の型安全な表現 (Priority: P1)
 
-エージェント開発者（003-agent-definition, 005-review-engine）が、レビュー結果を型安全に表現・検証するための共通モデルを利用する。Severity、ReviewIssue、AgentResult、ReviewReport 等の共通モデルにより、全エージェントが統一された構造でレビュー結果を出力できる。
+エージェント開発者（003-agent-definition, 005-review-engine）が、レビュー結果を型安全に表現・検証するための共通モデルを利用する。Severity、ReviewIssue、AgentResult（判別共用体）、ReviewReport 等の共通モデルにより、全エージェントが統一された構造でレビュー結果を出力できる。
 
 **Why this priority**: ドメインモデルは全レイヤーの基盤であり、これがなければエージェント結果の構造化も集約も不可能。最小限のMVPとしてこのモデル定義があれば、他の仕様が型安全に開発を進められる。
 
@@ -32,9 +32,11 @@
 
 1. **Given** Severity モデルが定義されている状態, **When** 定義された列挙値（Critical, Important, Suggestion, Nitpick）以外の値を設定しようとする, **Then** バリデーションエラーが発生する
 2. **Given** ReviewIssue モデルが定義されている状態, **When** 必須フィールド（エージェント名、重大度、説明）を省略してインスタンスを生成しようとする, **Then** バリデーションエラーが発生する
-3. **Given** AgentResult モデルが定義されている状態, **When** 正常完了時の結果（レビュー問題リスト・所要時間）を設定する, **Then** 型検証に成功しインスタンスが生成される
-4. **Given** AgentResult モデルが定義されている状態, **When** エラー発生時の結果（エラー情報・タイムアウト情報）を設定する, **Then** 型検証に成功しインスタンスが生成される
-5. **Given** ReviewReport モデルが定義されている状態, **When** 複数の AgentResult を集約する, **Then** 重大度別のグループ化と全体サマリー情報を保持したレポートが構成される
+3. **Given** AgentSuccess モデルが定義されている状態, **When** 正常完了時の結果（レビュー問題リスト・所要時間）を設定する, **Then** 型検証に成功しインスタンスが生成される
+4. **Given** AgentSuccess モデルが定義されている状態, **When** 必須フィールド（issues, elapsed_time）を省略する, **Then** バリデーションエラーが発生する（不完全な成功状態は型レベルで不可能）
+5. **Given** AgentError モデルが定義されている状態, **When** エラー情報を設定する, **Then** 型検証に成功しインスタンスが生成される
+6. **Given** AgentTimeout モデルが定義されている状態, **When** タイムアウト情報を設定する, **Then** 型検証に成功しインスタンスが生成される
+7. **Given** ReviewReport モデルが定義されている状態, **When** 複数の AgentResult（AgentSuccess・AgentError 混在）を集約する, **Then** 重大度別のグループ化と全体サマリー情報を保持したレポートが構成される
 
 ---
 
@@ -75,22 +77,26 @@ CLI やレビューエンジン（006-cli-interface, 005-review-engine）が、�
 
 ### Edge Cases
 
-- ReviewIssue のファイル位置（ファイルパス・行番号）はオプショナルであり、ファイル位置なしでもモデルは有効である（エージェントが行番号を特定できないケースに対応）
-- AgentResult の所要時間は正の値でなければならない。0以下の値はバリデーションエラーとなる
+- ReviewIssue のファイル位置（FileLocation）はオプショナルであり、ファイル位置なしでもモデルは有効である（エージェントが行番号を特定できないケースに対応）
+- AgentSuccess の所要時間は正の値でなければならない。0以下の値はバリデーションエラーとなる
 - SCHEMA_REGISTRY に同名のスキーマを重複登録しようとした場合、明確なエラーが発生する
 - 出力スキーマのフィールドに想定外の追加フィールドが含まれる場合の扱い（厳格モード: 追加フィールドを拒否する）
-- Severity の列挙値は大文字・小文字を区別せずに受け付けるが、内部表現は統一された形式で保持する
 - ReviewReport に AgentResult が0件の場合でもレポートは生成可能である（全エージェント失敗時の部分レポート対応、親仕様 SC-006）
+- AgentResult の JSON デシリアライズ時、判別キー（status フィールド）の値により正しいモデル（AgentSuccess/AgentError/AgentTimeout）が自動選択される
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
 - **FR-DM-001**: システムは重大度（Severity）を Critical、Important、Suggestion、Nitpick の4段階で定義し、上位の重大度ほど優先度が高い順序関係を持たなければならない
-- **FR-DM-002**: システムはレビュー問題（ReviewIssue）を統一的に表現するモデルを提供しなければならない。必須属性はエージェント名、重大度、説明とし、オプション属性としてファイルパス、行番号、推奨アクション、カテゴリを持つ
-- **FR-DM-003**: システムは単一エージェントの実行結果（AgentResult）を表現するモデルを提供しなければならない。ステータス列挙型（success/error/timeout）で状態を表し、正常完了時はレビュー問題リストと所要時間を、エラー時はエラー情報を、タイムアウト時はタイムアウト情報を状態ごとのオプショナルフィールドとして格納する
-- **FR-DM-004**: システムは全エージェントの結果を集約したレビューレポート（ReviewReport）を表現するモデルを提供しなければならない。レポートはレビュー問題の重大度別グループ化、エージェントごとのステータス・所要時間・コスト情報を含まなければならない
-- **FR-DM-005**: システムは共通ベースモデル（BaseAgentOutput: サマリーテキスト・ReviewIssue リスト）を定義し、以下の6種の出力スキーマはすべてこのベースモデルを継承しなければならない。各スキーマは固有フィールドを追加する
+- **FR-DM-002**: システムはレビュー問題（ReviewIssue）を統一的に表現するモデルを提供しなければならない。必須属性はエージェント名、重大度、説明とし、オプション属性としてファイル位置（FileLocation: ファイルパスと行番号の組）、推奨アクション、カテゴリを持つ。ファイルパスと行番号は FileLocation として一体で管理し、行番号がファイルパスなしに存在する不整合を型で防止する
+- **FR-DM-003**: システムは単一エージェントの実行結果を判別共用体（Discriminated Union）として提供しなければならない。以下の3つの状態モデルを定義し、判別キー（status フィールドの固定値）で型を一意に特定する:
+  - **AgentSuccess**: status="success"、エージェント名、レビュー問題リスト（必須）、所要時間（必須、正の値）
+  - **AgentError**: status="error"、エージェント名、エラー情報（必須）
+  - **AgentTimeout**: status="timeout"、エージェント名、タイムアウト情報（必須）
+  - **AgentResult** はこれら3型の Union 型とする
+- **FR-DM-004**: システムは全エージェントの結果を集約したレビューレポート（ReviewReport）を表現するモデルを提供しなければならない。レポートは AgentResult のリスト、エージェントごとのステータス・所要時間・コスト情報を含み、重大度別の ReviewIssue グループ化は AgentResult から計算導出するものとする
+- **FR-DM-005**: システムは共通ベースモデル（BaseAgentOutput: ReviewIssue リスト）を定義し、以下の6種の出力スキーマはすべてこのベースモデルを継承しなければならない。各スキーマは固有フィールドを追加する
   - **ScoredIssues**: スコア付き問題リスト（code-reviewer 等が使用）
   - **SeverityClassified**: 重大度分類問題リスト（silent-failure-hunter 等が使用）
   - **TestGapAssessment**: テストギャップ評価（pr-test-analyzer が使用）
@@ -99,19 +105,23 @@ CLI やレビューエンジン（006-cli-interface, 005-review-engine）が、�
   - **ImprovementSuggestions**: 改善提案リスト（code-simplifier が使用）
 - **FR-DM-006**: システムはスキーマレジストリ（SCHEMA_REGISTRY）を提供し、スキーマ名から対応するスキーマモデルを取得できなければならない。存在しないスキーマ名を指定した場合は明確なエラーを発生させなければならない
 - **FR-DM-007**: システムは各出力スキーマでエージェントの出力を型検証し、必須フィールドの欠損・型不一致・制約違反を検出できなければならない（親仕様 FR-004 の実現）
-- **FR-DM-008**: システムは Severity から終了コードへのマッピングを定義しなければならない。Critical → 1、Important → 2、Suggestion/Nitpick/問題なし → 0 とする（親仕様 FR-009 の基盤）
+- **FR-DM-008**: システムは Severity から終了コードへのマッピングを定義しなければならない。Critical → 1、Important → 2、Suggestion/Nitpick/問題なし → 0 とする（親仕様 FR-009 の基盤）。なお、実行エラー（終了コード 3）と入力エラー（終了コード 4）は Severity とは独立したエラー状態であり、005-review-engine および 006-cli-interface がそれぞれ定義する
 - **FR-DM-009**: 全モデルおよびスキーマは追加フィールドを拒否する厳格モードで動作しなければならない（想定外のデータ混入を防止する）
-- **FR-DM-010**: Severity の列挙値は入力時に大文字・小文字を区別せず受け付け、内部的には統一された正規形で保持しなければならない
-- **FR-DM-011**: JSONL 蓄積用のレビュー履歴レコード（ReviewHistoryRecord）を定義しなければならない。コミットハッシュ、ブランチ名、レビュー結果、エージェント情報をメタデータとして含む（親仕様 FR-026 の基盤）
+- **FR-DM-010**: Severity の列挙値はすべての入力経路で大文字・小文字を区別せず受け付けなければならない。内部表現は PascalCase（Critical, Important, Suggestion, Nitpick）で統一して保持する
+- **FR-DM-011**: JSONL 蓄積用のレビュー履歴レコード（ReviewHistoryRecord）を定義しなければならない。コミットハッシュ、ブランチ名、レビュー実行日時、レビューモード（diff/PR）、PR 番号（PR モード時）、AgentResult リスト、全体サマリーをメタデータとして含む（親仕様 FR-026 の基盤）
 
 ### Key Entities
 
-- **Severity（重大度）**: レビュー問題の深刻度を表す列挙型。Critical（重大）、Important（重要）、Suggestion（提案）、Nitpick（些細）の4段階。順序関係を持ち、終了コードへのマッピングを定義する
-- **ReviewIssue（レビュー問題）**: 各エージェントが検出した問題の統一表現。エージェント名・重大度・説明（必須）、ファイルパス・行番号・推奨アクション・カテゴリ（オプション）を持つ
-- **AgentResult（エージェント結果）**: 単一エージェントの実行結果。エージェント名とステータス列挙型（success/error/timeout）を必須属性とし、成功時のレビュー問題リスト・所要時間、エラー時のエラー情報、タイムアウト時のタイムアウト情報を状態ごとのオプショナル属性として持つ
-- **ReviewReport（レビューレポート）**: 全エージェントの結果を集約した最終出力。AgentResult のリスト、重大度別に分類された ReviewIssue、全体サマリー（総問題数、最大重大度、総実行時間、総コスト）を含む
+- **Severity（重大度）**: レビュー問題の深刻度を表す列挙型。Critical（重大）、Important（重要）、Suggestion（提案）、Nitpick（些細）の4段階。順序関係を持ち、終了コードへのマッピングを定義する。内部表現は PascalCase
+- **FileLocation（ファイル位置）**: レビュー問題のファイル内位置を表す値オブジェクト。ファイルパス（必須）と行番号（必須、正の整数）の組。ReviewIssue のオプション属性として使用し、行番号がファイルパスなしに存在する不整合を型で防止する
+- **ReviewIssue（レビュー問題）**: 各エージェントが検出した問題の統一表現。エージェント名・重大度・説明（必須）、ファイル位置（FileLocation、オプション）・推奨アクション・カテゴリ（オプション）を持つ
+- **AgentSuccess（エージェント成功結果）**: 判別共用体の成功バリアント。status="success"（判別キー）、エージェント名、レビュー問題リスト（必須）、所要時間（必須、正の値）を持つ
+- **AgentError（エージェントエラー結果）**: 判別共用体のエラーバリアント。status="error"（判別キー）、エージェント名、エラー情報（必須）を持つ
+- **AgentTimeout（エージェントタイムアウト結果）**: 判別共用体のタイムアウトバリアント。status="timeout"（判別キー）、エージェント名、タイムアウト情報（必須）を持つ
+- **AgentResult（エージェント結果）**: AgentSuccess | AgentError | AgentTimeout の判別共用体（Discriminated Union）。status フィールドの固定値で型を一意に特定する
+- **ReviewReport（レビューレポート）**: 全エージェントの結果を集約した最終出力。AgentResult のリスト、全体サマリー（総問題数、最大重大度、総実行時間、総コスト）を含む。重大度別の ReviewIssue グループ化は AgentResult から計算導出する
 - **ReviewHistoryRecord（レビュー履歴レコード）**: JSONL 蓄積用のレコード。コミットハッシュ、ブランチ名、レビュー実行日時、レビューモード（diff/PR）、PR 番号（PR モード時）、AgentResult リスト、全体サマリーを含む
-- **BaseAgentOutput（出力ベースモデル）**: 全出力スキーマの共通ベースモデル。サマリーテキストと ReviewIssue リストを共通属性として持つ。6種の出力スキーマはすべてこのベースを継承し、固有フィールドを追加する。ReviewReport への集約時に共通インターフェースとして機能する
+- **BaseAgentOutput（出力ベースモデル）**: 全出力スキーマの共通ベースモデル。ReviewIssue リストを共通属性として持つ。6種の出力スキーマはすべてこのベースを継承し、固有フィールドを追加する。ReviewReport への集約時に共通インターフェースとして機能する
 - **ScoredIssues（スコア付き問題）**: BaseAgentOutput を継承。数値スコアとレビュー問題のリストを組み合わせた出力スキーマ。コードレビューエージェント等が使用する
 - **SeverityClassified（重大度分類問題）**: BaseAgentOutput を継承。重大度でグループ化されたレビュー問題リストの出力スキーマ。サイレント障害検出エージェント等が使用する
 - **TestGapAssessment（テストギャップ評価）**: BaseAgentOutput を継承。テストカバレッジの欠落を評価する出力スキーマ。テスト分析エージェントが使用する
@@ -124,16 +134,17 @@ CLI やレビューエンジン（006-cli-interface, 005-review-engine）が、�
 
 ### Measurable Outcomes
 
-- **SC-DM-001**: 全ドメインモデル（Severity, ReviewIssue, AgentResult, ReviewReport, ReviewHistoryRecord）に対して、有効なデータで型検証が成功し、無効なデータで明確なバリデーションエラーが発生する
+- **SC-DM-001**: 全ドメインモデル（Severity, FileLocation, ReviewIssue, AgentSuccess, AgentError, AgentTimeout, ReviewReport, ReviewHistoryRecord）に対して、有効なデータで型検証が成功し、無効なデータで明確なバリデーションエラーが発生する
 - **SC-DM-002**: 6種の出力スキーマすべてがスキーマレジストリに登録され、名前で検索・取得できる
 - **SC-DM-003**: Severity のマッピングにより、全パターン（Critical/Important/Suggestion/Nitpick/問題なし）の終了コードが親仕様 FR-009 の定義と一致する
 - **SC-DM-004**: 出力スキーマで必須フィールドが欠損したデータを検証した場合、どのフィールドが不正かを特定可能なエラーメッセージが生成される
 - **SC-DM-005**: 全モデル・スキーマが厳格モードで動作し、定義外の追加フィールドを含むデータがバリデーションエラーとなる
-- **SC-DM-006**: 依存先の仕様（003-agent-definition, 005-review-engine, 007-output-format）が必要とする全モデル・スキーマが過不足なく定義されている
+- **SC-DM-006**: 親仕様 001 で定義された全 Key Entities（Severity, ReviewIssue, AgentResult, ReviewReport, ReviewHistoryRecord, 6種の出力スキーマ, SCHEMA_REGISTRY）に対応するモデルが本仕様で定義されている
 
 ## Assumptions
 
 - pydantic-ai の `result_type` が Pydantic モデルを要求するため、本仕様の全モデル・スキーマは Pydantic 互換である必要がある。これは実装上の選択ではなくフレームワークによるアーキテクチャ制約である
 - 出力スキーマの具体的なフィールド構成は、各ビルトインエージェント（003-agent-definition で定義予定）の要件に基づいて最終確定する。本仕様では親仕様の Key Entities と6種のスキーマ分類に基づくフレームワークを定義する
-- コスト情報（AgentResult・ReviewReport に含む）の具体的な構造（トークン数、API コスト等）は、利用する LLM プロバイダの仕様に依存するため、最小限の共通構造（入力トークン数、出力トークン数、合計コスト）で定義する
+- BaseAgentOutput のサマリーテキスト属性の要否は、003-agent-definition で各エージェントの出力要件が確定した段階で再検討する。現時点では ReviewIssue リストのみを共通属性とする
+- コスト情報（AgentSuccess・ReviewReport に含む）はオプショナル属性とする。LLM プロバイダによっては取得できない場合があるため。構造は最小限の共通構造（入力トークン数、出力トークン数、合計コスト）とする
 - ReviewHistoryRecord の直列化フォーマット（JSON フィールド名、日時形式等）は 007-output-format との協調で最終決定するが、モデル構造は本仕様で定義する

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,14 +28,14 @@ graph TD
     005 --> 008[008-github-integration]
 ```
 
-> **スキーマの所属境界**: SCHEMA_REGISTRY と各エージェントの出力スキーマ（ScoredIssuesResult 等）は **002-domain-models** に含まれる。これらはローダー（003）・ランナー（005）が参照する「ドメインモデル」であり、出力フォーマット（007）はフォーマッター・ストレージのみを担当する。この設計により依存方向が一方向に整理される。
+> **スキーマの所属境界**: SCHEMA_REGISTRY と各エージェントの出力スキーマ（ScoredIssues 等）は **002-domain-models** に含まれる。これらはローダー（003）・ランナー（005）が参照する「ドメインモデル」であり、出力フォーマット（007）はフォーマッター・ストレージのみを担当する。この設計により依存方向が一方向に整理される。
 
 ## 仕様一覧
 
 | ID | 名称 | 状態 | 優先度 | 概要 |
 |----|------|------|--------|------|
 | [001-architecture-spec](./001-architecture-spec/spec.md) | アーキテクチャ仕様（親） | Draft | - | 全体アーキテクチャ、ユーザーストーリー、機能要件、成功基準を定義する親仕様 |
-| 002-domain-models | ドメインモデル・出力スキーマ | 未着手 | P0 | Severity, ReviewIssue, AgentResult, ReviewReport 等の共通モデル、6種の出力スキーマ、SCHEMA_REGISTRY、Severity マッピング |
+| [002-domain-models](./002-domain-models/spec.md) | ドメインモデル・出力スキーマ | Draft | P0 | Severity, ReviewIssue, AgentResult, ReviewReport 等の共通モデル、6種の出力スキーマ、SCHEMA_REGISTRY、Severity マッピング |
 | 003-agent-definition | エージェント定義・ローダー | 未着手 | P1 | TOML 定義フォーマット、AgentDefinition、ApplicabilityRule、ビルトイン6エージェント、ローダー・セレクター |
 | 004-configuration | 設定管理 | 未着手 | P2 | HachimokuConfig、4層階層解決、CLAUDE.md 検出・注入 |
 | 005-review-engine | レビュー実行エンジン | 未着手 | P1 | 逐次・並列実行、二段階タイムアウト、部分失敗許容、結果集約、シグナルハンドリング |


### PR DESCRIPTION
## Summary
- P0 基盤仕様として 002-domain-models を新規作成
- 共通ドメインモデル（Severity, ReviewIssue, AgentResult, ReviewReport, ReviewHistoryRecord）を定義
- 6種の出力スキーマと共通ベースモデル（BaseAgentOutput）の継承構造を定義
- SCHEMA_REGISTRY、Severity→終了コードマッピングを定義
- pydantic-ai アーキテクチャ制約を明確化
- 仕様品質チェックリストを作成・全項目パス

## Test plan
- [ ] spec.md の全セクション（User Scenarios, Requirements, Success Criteria）が完備されていることを確認
- [ ] 親仕様（001-architecture-spec）の FR-004, FR-009, FR-026 との整合性を確認
- [ ] README.md の仕様一覧・依存関係図との整合性を確認
- [ ] checklists/requirements.md の全項目がパスしていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)