### PR TITLE
feat: 002-domain-models 実装計画の策定

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 requires-python = ">=3.13"
 dependencies = [
     "claudecode-model",
+    "pydantic>=2.12.5",
     "typer>=0.21.1",
 ]
 

--- a/specs/002-domain-models/plan.md
+++ b/specs/002-domain-models/plan.md
@@ -23,15 +23,23 @@
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-Constitution ファイルがテンプレート状態（プレースホルダーのみ）のため、具体的なゲート検証は該当なし。CLAUDE.md のルール（フォールバック禁止、TDD、型安全、DRY）を遵守する。
+hachimoku Constitution v1.0.0 に基づくゲート検証結果:
 
-**適用ルール**:
-- フォールバック禁止: エラー時にデフォルト値で続行しない → 全モデルで `extra="forbid"`、未登録スキーマは例外送出
-- TDD: テスト先行で実装
-- 型安全: 全関数に型注釈、`Any` 型禁止、`| None` 構文優先
-- DRY: 共通ベースモデル（`HachimokuBaseModel`）で `ConfigDict` を一元管理
+| Article | 原則 | 適用結果 | 備考 |
+|---------|------|---------|------|
+| Art.1 テストファースト | **非交渉的** | PASS | TDD サイクルを quickstart.md に定義。実装時に Red→Green→Refactor を厳守 |
+| Art.2 ドキュメント整合性 | **非交渉的** | PASS | spec.md → plan.md → data-model.md → contracts/models.py の一貫性を維持 |
+| Art.3 CLI 設計準拠 | 該当 | N/A | 本仕様はモデル定義のみ。CLI は 006-cli-interface が担当 |
+| Art.4 シンプルさ | 該当 | PASS | 単一パッケージ構成。不要なラッパーなし。Pydantic の機能を直接使用 |
+| Art.5 コード品質基準 | **非交渉的** | PASS | ruff + mypy をコミット前に実行。quickstart.md に手順記載 |
+| Art.6 データ正確性 | **非交渉的** | PASS | マジックナンバー禁止（終了コードは名前付き定数）。暗黙的デフォルト値なし |
+| Art.7 DRY 原則 | **非交渉的** | PASS | `HachimokuBaseModel` で ConfigDict 一元管理。`ReviewSummary` で共通サマリーを共有。`CommitHash` 型エイリアスで重複排除 |
+| Art.8 リファクタリング | 該当 | PASS | 新規実装のため V2 クラスなし |
+| Art.9 Python 型安全性 | **非交渉的** | PASS | 全フィールドに型注釈。`Any` 型不使用。`\| None` 構文優先 |
+| Art.10 Docstring 標準 | 推奨 | PASS | Google-style docstring を contracts/models.py に記載 |
+| Art.11 命名規則 | **非交渉的** | PASS | ブランチ名 `002-domain-models` は規約準拠 |
 
-**結果**: ゲート通過（違反なし）
+**結果**: 全ゲート通過（違反なし）
 
 ## Project Structure
 

--- a/specs/002-domain-models/quickstart.md
+++ b/specs/002-domain-models/quickstart.md
@@ -10,10 +10,10 @@
 
 ```bash
 # 依存関係のインストール（pydantic は pydantic-ai 経由で導入済み）
-uv --directory /home/driller/repo/hachimoku sync
+uv --directory $PROJECT_ROOT sync
 
 # pytest を dev dependency に追加（未追加の場合）
-uv --directory /home/driller/repo/hachimoku add --dev pytest
+uv --directory $PROJECT_ROOT add --dev pytest
 ```
 
 ## ディレクトリ構成
@@ -57,20 +57,20 @@ tests/unit/models/
 
 ```bash
 # 1. テスト作成後、Red 確認
-uv --directory /home/driller/repo/hachimoku run pytest tests/unit/models/test_severity.py -v
+uv --directory $PROJECT_ROOT run pytest tests/unit/models/test_severity.py -v
 # → FAILED (期待通り)
 
 # 2. 実装後、Green 確認
-uv --directory /home/driller/repo/hachimoku run pytest tests/unit/models/test_severity.py -v
+uv --directory $PROJECT_ROOT run pytest tests/unit/models/test_severity.py -v
 # → PASSED
 
 # 3. 全テスト実行
-uv --directory /home/driller/repo/hachimoku run pytest tests/unit/models/ -v
+uv --directory $PROJECT_ROOT run pytest tests/unit/models/ -v
 
 # 4. 品質チェック
-uv --directory /home/driller/repo/hachimoku run ruff check --fix src/hachimoku/models/
-uv --directory /home/driller/repo/hachimoku run ruff format src/hachimoku/models/
-uv --directory /home/driller/repo/hachimoku run mypy src/hachimoku/models/
+uv --directory $PROJECT_ROOT run ruff check --fix src/hachimoku/models/
+uv --directory $PROJECT_ROOT run ruff format src/hachimoku/models/
+uv --directory $PROJECT_ROOT run mypy src/hachimoku/models/
 ```
 
 ## 使用例
@@ -79,6 +79,7 @@ uv --directory /home/driller/repo/hachimoku run mypy src/hachimoku/models/
 from hachimoku.models import (
     Severity,
     ReviewIssue,
+    ReviewSummary,
     FileLocation,
     AgentSuccess,
     AgentError,
@@ -116,16 +117,18 @@ error: AgentResult = AgentError(
     error_message="API rate limit exceeded",
 )
 
-# ReviewReport
+# ReviewReport（summary に ReviewSummary を委譲）
 report = ReviewReport(
     results=[success, error],
-    total_issues=1,
-    max_severity=Severity.CRITICAL,
-    total_elapsed_time=1.5,
+    summary=ReviewSummary(
+        total_issues=1,
+        max_severity=Severity.CRITICAL,
+        total_elapsed_time=1.5,
+    ),
 )
 
 # 終了コード決定
-exit_code = determine_exit_code(report.max_severity)
+exit_code = determine_exit_code(report.summary.max_severity)
 assert exit_code == 1  # Critical → 1
 
 # SCHEMA_REGISTRY

--- a/uv.lock
+++ b/uv.lock
@@ -882,6 +882,7 @@ version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "claudecode-model" },
+    { name = "pydantic" },
     { name = "typer" },
 ]
 
@@ -896,6 +897,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "claudecode-model", git = "https://github.com/drillan/claudecode-model.git" },
+    { name = "pydantic", specifier = ">=2.12.5" },
     { name = "typer", specifier = ">=0.21.1" },
 ]
 


### PR DESCRIPTION
## Summary

- 002-domain-models の実装計画（Phase 0: リサーチ、Phase 1: 設計・契約）を策定
- Pydantic v2 ベースのドメインモデル設計アーティファクトを生成（plan.md, research.md, data-model.md, contracts/models.py, quickstart.md）
- 判別共用体パターン、`HachimokuBaseModel` による厳格モード一元管理、Severity → 終了コードマッピング等の技術決定を文書化

## Test plan

- [ ] data-model.md のエンティティ関係図が仕様 spec.md の全 Key Entities をカバーしていることを確認
- [ ] contracts/models.py の型シグネチャが仕様の FR-DM-001〜FR-DM-011 を網羅していることを確認
- [ ] research.md の設計決定が plan.md の Technical Context と整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)