### PR TITLE
feat: 002-domain-models タスク生成と仕様整合性修正

### DIFF
--- a/specs/002-domain-models/plan.md
+++ b/specs/002-domain-models/plan.md
@@ -67,7 +67,7 @@ src/hachimoku/
     ├── severity.py          # Severity 列挙型、終了コードマッピング
     ├── review.py            # FileLocation, ReviewIssue
     ├── agent_result.py      # AgentSuccess, AgentError, AgentTimeout, AgentResult
-    ├── report.py            # ReviewReport
+    ├── report.py            # ReviewSummary, ReviewReport
     ├── schemas/
     │   ├── __init__.py      # SCHEMA_REGISTRY, スキーマ公開 API
     │   ├── _base.py         # BaseAgentOutput

--- a/specs/002-domain-models/quickstart.md
+++ b/specs/002-domain-models/quickstart.md
@@ -32,6 +32,7 @@ src/hachimoku/models/
 └── history.py               # ReviewHistoryRecord
 
 tests/unit/models/
+├── test_base.py
 ├── test_severity.py
 ├── test_review.py
 ├── test_agent_result.py

--- a/specs/002-domain-models/spec.md
+++ b/specs/002-domain-models/spec.md
@@ -131,7 +131,8 @@ CLI やレビューエンジン（006-cli-interface, 005-review-engine）が、�
 - **AgentError（エージェントエラー結果）**: 判別共用体のエラーバリアント。status="error"（判別キー）、エージェント名、エラー情報（必須）を持つ
 - **AgentTimeout（エージェントタイムアウト結果）**: 判別共用体のタイムアウトバリアント。status="timeout"（判別キー）、エージェント名、タイムアウト情報（必須）を持つ
 - **AgentResult（エージェント結果）**: AgentSuccess | AgentError | AgentTimeout の判別共用体（Discriminated Union）。status フィールドの固定値で型を一意に特定する
-- **ReviewReport（レビューレポート）**: 全エージェントの結果を集約した最終出力。AgentResult のリストと全体サマリー（ReviewSummary: 総問題数、最大重大度、総実行時間、総コスト情報（CostInfo、オプション））を含む。重大度別の ReviewIssue グループ化は AgentResult から計算導出する
+- **ReviewReport（レビューレポート）**: 全エージェントの結果を集約した最終出力。AgentResult のリストと全体サマリー（ReviewSummary）を含む。重大度別の ReviewIssue グループ化は AgentResult から計算導出する
+- **ReviewSummary（レビューサマリー）**: レビュー結果の全体サマリー情報。ReviewReport および全ての ReviewHistoryRecord バリアント（DiffReviewRecord、PRReviewRecord、FileReviewRecord）で共有される共通エンティティ。総問題数（非負整数）、最大重大度（Severity | None）、総実行時間（非負浮動小数点）、総コスト情報（CostInfo、オプション）を持つ
 - **DiffReviewRecord（diff レビューレコード）**: 判別共用体のバリアント。review_mode="diff"（判別キー）、コミットハッシュ（完全40文字の16進数文字列）、ブランチ名、レビュー実行日時、AgentResult リスト、全体サマリーを持つ
 - **PRReviewRecord（PR レビューレコード）**: 判別共用体のバリアント。review_mode="pr"（判別キー）、コミットハッシュ（完全40文字の16進数文字列）、PR 番号、ブランチ名、レビュー実行日時、AgentResult リスト、全体サマリーを持つ
 - **FileReviewRecord（file レビューレコード）**: 判別共用体のバリアント。review_mode="file"（判別キー）、ファイルパスリスト（1要素以上、重複排除済み）、レビュー実行日時、作業ディレクトリ（絶対パス、相対パスはバリデーションエラー）、AgentResult リスト、全体サマリーを持つ

--- a/specs/002-domain-models/tasks.md
+++ b/specs/002-domain-models/tasks.md
@@ -51,7 +51,7 @@
 
 ## Phase 3: User Story 1 - 共通ドメインモデルによるエージェント結果の型安全な表現 (Priority: P1) 🎯 MVP
 
-**Goal**: Severity, FileLocation, ReviewIssue, CostInfo, AgentResult（判別共用体）、ReviewSummary, ReviewReport を実装し、エージェント結果を型安全に表現可能にする
+**Goal**: FileLocation, ReviewIssue, CostInfo, AgentResult（判別共用体）、ReviewSummary, ReviewReport を実装し、Phase 2 で構築した Severity を基盤としてエージェント結果を型安全に表現可能にする
 
 **Independent Test**: モデルクラスをインポートし、各フィールドの型検証・制約検証・判別共用体のデシリアライズが正しく動作する
 
@@ -61,7 +61,7 @@
 
 - [ ] T010 [P] [US1] Write tests for `FileLocation` and `ReviewIssue` in `tests/unit/models/test_review.py`: FileLocation の制約（file_path 空文字不可、line_number >= 1）、ReviewIssue の必須フィールド検証（agent_name/severity/description）、オプションフィールド（location/suggestion/category）のデフォルト None、Severity の大文字小文字非依存入力（`field_validator` 経由）、extra="forbid" による追加フィールド拒否
 - [ ] T011 [P] [US1] Write tests for `CostInfo`, `AgentSuccess`, `AgentError`, `AgentTimeout`, `AgentResult` in `tests/unit/models/test_agent_result.py`: CostInfo の制約（非負値）、AgentSuccess の制約（elapsed_time > 0, cost オプション）、AgentError の制約（error_message 空文字不可）、AgentTimeout の制約（timeout_seconds > 0）、AgentResult の判別共用体デシリアライズ（status フィールドによる型自動選択）、extra="forbid" 検証
-- [ ] T012 [P] [US1] Write tests for `ReviewSummary` and `ReviewReport` in `tests/unit/models/test_report.py`: ReviewSummary の制約（total_issues >= 0, total_elapsed_time >= 0.0, max_severity None 許容）、ReviewReport の results 空リスト許容（SC-006）、extra="forbid" 検証
+- [ ] T012 [P] [US1] Write tests for `ReviewSummary` and `ReviewReport` in `tests/unit/models/test_report.py`: ReviewSummary の制約（total_issues >= 0, total_elapsed_time >= 0.0, max_severity None 許容）、ReviewReport の results 空リスト許容（親仕様 SC-006）、extra="forbid" 検証
 
 ### Implementation for User Story 1
 


### PR DESCRIPTION
## Summary
- 002-domain-models の tasks.md を新規生成（37タスク、7フェーズ構成、TDD サイクル込み）
- spec.md の FR-DM-004 および Key Entities ReviewReport を contracts/models.py と整合するよう修正
- plan.md のテストファイルリストに `test_base.py` を追加
- tasks.md T034 の「補助モデル」を具体的なクラス名に展開

## Test plan
- [ ] tasks.md の全37タスクがチェックリスト形式（`- [ ] [TaskID] ...`）に準拠していること
- [ ] spec.md の FR-DM-004 が contracts/models.py の ReviewReport 定義と整合していること
- [ ] plan.md のテストファイルリストが tasks.md のテストタスクと一致していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)