### PR TITLE
feat(#31): Phase/ApplicabilityRule/LoadError モデル定義

### DIFF
--- a/specs/003-agent-definition/contracts/agent.py
+++ b/specs/003-agent-definition/contracts/agent.py
@@ -66,12 +66,12 @@ class ApplicabilityRule(HachimokuBaseModel):
     """
 
     always: bool = False
-    file_patterns: list[str] = Field(default_factory=list)
-    content_patterns: list[str] = Field(default_factory=list)
+    file_patterns: tuple[str, ...] = ()
+    content_patterns: tuple[str, ...] = ()
 
     @field_validator("content_patterns")
     @classmethod
-    def validate_regex_patterns(cls, v: list[str]) -> list[str]:
+    def validate_regex_patterns(cls, v: tuple[str, ...]) -> tuple[str, ...]:
         """各パターンが有効な正規表現であることを検証する。"""
         for pattern in v:
             try:

--- a/specs/003-agent-definition/data-model.md
+++ b/specs/003-agent-definition/data-model.md
@@ -27,8 +27,8 @@ erDiagram
 
     ApplicabilityRule {
         bool always "常時適用フラグ（デフォルト: false）"
-        list_str file_patterns "fnmatch グロブパターン"
-        list_str content_patterns "Python re 正規表現"
+        tuple_str file_patterns "fnmatch グロブパターン"
+        tuple_str content_patterns "Python re 正規表現"
     }
 
     Phase {
@@ -73,8 +73,8 @@ erDiagram
 | Field | Type | Default | Constraints | Description |
 |-------|------|---------|-------------|-------------|
 | `always` | `bool` | `False` | - | 常時適用フラグ |
-| `file_patterns` | `list[str]` | `[]` | fnmatch 互換グロブ | ファイル名パターン |
-| `content_patterns` | `list[str]` | `[]` | Python re 互換正規表現 | コンテンツパターン |
+| `file_patterns` | `tuple[str, ...]` | `()` | fnmatch 互換グロブ | ファイル名パターン |
+| `content_patterns` | `tuple[str, ...]` | `()` | Python re 互換正規表現 | コンテンツパターン |
 
 **Validation Rules**:
 - `content_patterns` の各要素は有効な正規表現であること（`re.compile()` で検証、失敗時は `ValueError`）

--- a/src/hachimoku/agents/models.py
+++ b/src/hachimoku/agents/models.py
@@ -33,12 +33,17 @@ class Phase(StrEnum):
     FINAL = "final"
 
 
+# Phase の順序定義（数値が小さいほど先に実行）
 PHASE_ORDER: Final[Mapping[Phase, int]] = MappingProxyType(
     {
         Phase.EARLY: 0,
         Phase.MAIN: 1,
         Phase.FINAL: 2,
     }
+)
+
+assert set(PHASE_ORDER.keys()) == set(Phase), (
+    "PHASE_ORDER keys must match Phase members"
 )
 
 
@@ -60,12 +65,12 @@ class ApplicabilityRule(HachimokuBaseModel):
     """
 
     always: bool = False
-    file_patterns: list[str] = Field(default_factory=list)
-    content_patterns: list[str] = Field(default_factory=list)
+    file_patterns: tuple[str, ...] = ()
+    content_patterns: tuple[str, ...] = ()
 
     @field_validator("content_patterns")
     @classmethod
-    def validate_regex_patterns(cls, v: list[str]) -> list[str]:
+    def validate_regex_patterns(cls, v: tuple[str, ...]) -> tuple[str, ...]:
         """各パターンが有効な正規表現であることを検証する。"""
         for pattern in v:
             try:


### PR DESCRIPTION
## Summary

- `Phase` StrEnum (EARLY/MAIN/FINAL) と `PHASE_ORDER` 定数を `MappingProxyType` で読み取り専用化して実装
- `ApplicabilityRule` モデルを `field_validator` による正規表現検証付きで実装
- `LoadError` モデルを `min_length=1` 制約付きで実装
- 6テストクラス・29テストメソッドで TDD 検証済み

## Scope Change

- `LoadResult` は `AgentDefinition` と密結合のため、次の Issue (AgentDefinition) に移動

## Test plan

- [x] `uv run pytest tests/unit/agents/test_models.py -v` — 29テスト全 PASS
- [x] `uv run ruff check . && ruff format --check . && mypy .` — 品質チェック通過
- [x] `uv run pytest -v` — 全315テスト PASS（既存テスト影響なし）

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)