### PR TITLE
feat(#35): エージェントセレクター実装 (T025-T029)

### DIFF
--- a/src/hachimoku/agents/selector.py
+++ b/src/hachimoku/agents/selector.py
@@ -22,7 +22,7 @@ def _matches(
 ) -> bool:
     """適用ルールを評価し、エージェントが適用されるかを判定する。
 
-    評価ロジック（OR 短絡評価）:
+    評価ロジック（OR 条件、早期リターン）:
     1. always=True → True
     2. file_patterns のいずれかにファイル名（basename）がマッチ → True
     3. content_patterns のいずれかにコンテンツがマッチ → True


### PR DESCRIPTION
## Summary

- `_matches(rule, file_paths, content) -> bool`: ApplicabilityRule の OR 短絡評価（always → file_patterns fnmatch → content_patterns re.search）
- `select_agents(agents, file_paths, content) -> list[AgentDefinition]`: マッチ判定 + Phase 順（early→main→final）・同 Phase 名前辞書順ソート
- テスト30件 all green、品質チェック通過（ruff + mypy）

Closes #35

## Test plan

- [x] `_matches` テスト20件: always=true, file_patterns マッチ/不一致, content_patterns マッチ/不一致, OR 条件, 無条件
- [x] `select_agents` テスト10件: 選択, Phase 順ソート, 名前辞書順, 空入力, 全不適用
- [x] 全体テスト418件 all passed
- [x] `ruff check --fix . && ruff format . && mypy .` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)