### PR TITLE
feat(#50): TOML ローダー — US2 (T020-T024)

### DIFF
--- a/src/hachimoku/config/_loader.py
+++ b/src/hachimoku/config/_loader.py
@@ -1,6 +1,6 @@
 """TOML 設定ファイルローダー。
 
-FR-CF-004: .hachimoku/config.toml の TOML パース
+FR-CF-004: .hachimoku/config.toml の TOML パース（バリデーションは _resolver.py が担当）
 FR-CF-005: pyproject.toml の [tool.hachimoku] セクション読み込み
 R-009: アクセスエラーは例外として送出
 """
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import tomllib
 from pathlib import Path
+
+_TOOL_SECTION_KEY: str = "tool"
+_HACHIMOKU_SECTION_KEY: str = "hachimoku"
 
 
 def load_toml_config(path: Path) -> dict[str, object]:
@@ -26,7 +29,7 @@ def load_toml_config(path: Path) -> dict[str, object]:
         FileNotFoundError: ファイルが存在しない場合。
     """
     with path.open("rb") as f:
-        return tomllib.load(f)  # type: ignore[return-value]
+        return tomllib.load(f)
 
 
 def load_pyproject_config(path: Path) -> dict[str, object] | None:
@@ -42,14 +45,15 @@ def load_pyproject_config(path: Path) -> dict[str, object] | None:
 
     Raises:
         tomllib.TOMLDecodeError: TOML 構文エラーの場合。
+        FileNotFoundError: ファイルが存在しない場合。
         PermissionError: 読み取り権限がない場合。
     """
     with path.open("rb") as f:
         data = tomllib.load(f)
-    tool = data.get("tool")
+    tool = data.get(_TOOL_SECTION_KEY)
     if not isinstance(tool, dict):
         return None
-    hachimoku = tool.get("hachimoku")
+    hachimoku = tool.get(_HACHIMOKU_SECTION_KEY)
     if not isinstance(hachimoku, dict):
         return None
-    return hachimoku  # type: ignore[return-value]
+    return hachimoku


### PR DESCRIPTION
## Summary
- `load_toml_config()` と `load_pyproject_config()` を TDD で実装
- `.hachimoku/config.toml` の TOML 読み込みと `pyproject.toml [tool.hachimoku]` セクション抽出
- 11テストケース（正常系・エラー系）全 PASS、品質チェック合格

## Test plan
- [x] `uv run pytest tests/unit/config/test_loader.py -v` — 11テスト PASS
- [x] `uv run pytest` — 全515テスト PASS（回帰なし）
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy .` — 品質チェック合格

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)