### PR TITLE
test(#80): ReviewTarget・ReviewInstructionBuilder のエッジケーステスト追加

### DIFF
--- a/tests/unit/engine/test_instruction.py
+++ b/tests/unit/engine/test_instruction.py
@@ -92,7 +92,7 @@ class TestBuildReviewInstructionIssue:
 
 
 class TestBuildReviewInstructionFileEdgeCases:
-    """build_review_instruction の file モードエッジケースを検証（US5-AC3, AC4）。"""
+    """build_review_instruction の file モードエッジケースを検証（US5-AC3, US5-AC4）。"""
 
     def test_glob_pattern_included_in_instruction(self) -> None:
         """glob パターンがレビュー指示に含まれる（US5-AC4）。"""
@@ -126,7 +126,7 @@ class TestBuildReviewInstructionIssueCombinations:
     """全モードにおける issue_number 有無の組み合わせを検証（FR-RE-011）。"""
 
     def test_diff_with_issue_includes_both(self) -> None:
-        """diff モード + issue_number で両方含まれる。"""
+        """diff モード + issue_number で両方含まれる（Related Issue ヘッダ含有を既存テストに追加検証）。"""
         target = DiffTarget(base_branch="main", issue_number=42)
         instruction = build_review_instruction(target)
         assert "main" in instruction
@@ -137,7 +137,7 @@ class TestBuildReviewInstructionIssueCombinations:
         """PR モード + issue_number で両方含まれる。"""
         target = PRTarget(pr_number=10, issue_number=42)
         instruction = build_review_instruction(target)
-        assert "10" in instruction
+        assert "#10" in instruction
         assert "#42" in instruction
 
     def test_file_with_issue_includes_both(self) -> None:

--- a/tests/unit/engine/test_target.py
+++ b/tests/unit/engine/test_target.py
@@ -70,7 +70,11 @@ class TestDiffTargetValid:
             target.base_branch = "develop"  # type: ignore[misc]
 
     def test_whitespace_only_base_branch_accepted(self) -> None:
-        """空白のみの base_branch は min_length=1 を満たすため受け入れられる。"""
+        """空白のみの base_branch は min_length=1 を満たすため受け入れられる。
+
+        注: 現時点では strip バリデーション未適用。
+        実行時の git コマンド失敗は CLI 層で捕捉される想定。
+        """
         target = DiffTarget(base_branch=" ")
         assert target.base_branch == " "
 


### PR DESCRIPTION
## Summary

- US5 受け入れシナリオの網羅性を証明するエッジケーステストを追加
- T015: `test_target.py` に 7 テスト追加（glob パターン、ディレクトリ、混在パス、負 issue_number、空白文字列、判別共用体デシリアライズ）
- T016: `test_instruction.py` に 9 テスト追加（file モードエッジケース、全モード × issue_number 有無の組み合わせ）
- T017: 既存実装がエッジケースを正しく処理済みのため実装変更なし

## Test plan

- [x] `uv run pytest tests/unit/engine/test_target.py -v` — 37 passed
- [x] `uv run pytest tests/unit/engine/test_instruction.py -v` — 19 passed
- [x] `uv run pytest` — 720 passed
- [x] `uv run ruff check --fix . && uv run ruff format . && uv run mypy .` — all passed

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)