### PR TITLE
docs: エージェント定義・設定管理のドキュメント追加

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,203 @@
+# エージェント定義
+
+hachimoku のレビューエージェントは TOML ファイルで定義されます。
+コード変更なしにエージェントの追加・カスタマイズが可能なデータ駆動型アーキテクチャを採用しています。
+6つのビルトインエージェントを標準提供し、プロジェクト固有のカスタムエージェントも追加できます。
+
+```{contents}
+:depth: 2
+:local:
+```
+
+## ビルトインエージェント
+
+以下の6つのエージェントがパッケージに同梱されています。
+
+| エージェント名 | 説明 | 出力スキーマ | フェーズ | 適用条件 |
+|---------------|------|-------------|---------|---------|
+| code-reviewer | コード品質・バグ検出 | scored_issues | main | 常時適用 |
+| silent-failure-hunter | サイレント障害の検出 | severity_classified | main | content_patterns |
+| pr-test-analyzer | テストカバレッジの評価 | test_gap_assessment | main | file_patterns |
+| type-design-analyzer | 型設計の分析 | multi_dimensional_analysis | main | file_patterns + content_patterns |
+| comment-analyzer | コメントの正確性分析 | category_classification | final | content_patterns |
+| code-simplifier | コード簡潔化の提案 | improvement_suggestions | final | 常時適用 |
+
+出力スキーマの詳細は [出力スキーマ](output-schemas) を参照してください。
+
+## TOML 定義ファイル形式
+
+エージェント定義は以下の形式の TOML ファイルで記述します。
+
+```{code-block} toml
+name = "code-reviewer"
+description = "コード品質・バグ・ベストプラクティスの総合レビュー"
+model = "claude-sonnet-4-5-20250929"
+output_schema = "scored_issues"
+phase = "main"
+system_prompt = """
+You are an expert code reviewer. Analyze the provided code changes and identify:
+- Bugs and logical errors
+- Code quality issues
+- Violations of best practices and coding standards
+"""
+
+[applicability]
+always = true
+```
+
+### フィールド一覧
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|---|------|------|
+| `name` | `str` | Yes | エージェント名。アルファベット小文字・数字・ハイフンのみ（`^[a-z0-9-]+$`） |
+| `description` | `str` | Yes | エージェントの説明 |
+| `model` | `str` | Yes | 使用する LLM モデル名 |
+| `output_schema` | `str` | Yes | [SCHEMA_REGISTRY](schema-registry) に登録されたスキーマ名 |
+| `system_prompt` | `str` | Yes | エージェントのシステムプロンプト |
+| `allowed_tools` | `list[str]` | No | 許可するツールカテゴリのリスト。デフォルト: 空 |
+| `phase` | `str` | No | 実行フェーズ。デフォルト: `"main"` |
+
+`[applicability]` テーブル:
+
+| フィールド | 型 | デフォルト | 説明 |
+|-----------|---|----------|------|
+| `always` | `bool` | `false` | 常時適用フラグ |
+| `file_patterns` | `list[str]` | `[]` | fnmatch パターンのリスト |
+| `content_patterns` | `list[str]` | `[]` | 正規表現パターンのリスト |
+
+`[applicability]` テーブルを省略した場合、`always = true` がデフォルトとして適用されます。
+
+## Phase（実行フェーズ）
+
+エージェントの実行順序を制御するフェーズです。
+エージェントはフェーズ順に実行され、同フェーズ内では名前の辞書順で実行されます。
+
+| 値 | 実行順序 | 説明 |
+|----|---------|------|
+| `early` | 0 | 前処理フェーズ |
+| `main` | 1 | メインレビューフェーズ |
+| `final` | 2 | 後処理フェーズ |
+
+```{code-block} python
+from hachimoku.agents import Phase, PHASE_ORDER
+
+assert PHASE_ORDER[Phase.EARLY] < PHASE_ORDER[Phase.MAIN] < PHASE_ORDER[Phase.FINAL]
+```
+
+## ApplicabilityRule（適用条件）
+
+エージェントがレビュー対象に適用されるかどうかを判定する条件です。
+
+条件評価ロジック:
+
+1. `always = true` の場合、常に適用
+2. `file_patterns` のいずれかにファイル名（basename）がマッチすれば適用
+3. `content_patterns` のいずれかにコンテンツがマッチすれば適用
+4. 上記いずれも該当しなければ不適用
+
+`file_patterns` と `content_patterns` は OR 関係です。
+
+### ビルトインエージェントの適用条件
+
+| エージェント | 条件 | パターン |
+|------------|------|---------|
+| code-reviewer | `always = true` | - |
+| silent-failure-hunter | content_patterns | `try\s*:`, `except\s`, `catch\s*\(`, `\.catch\s*\(` |
+| pr-test-analyzer | file_patterns | `test_*.py`, `*_test.py`, `*.test.ts`, `*.test.js`, `*.spec.ts`, `*.spec.js` |
+| type-design-analyzer | file_patterns + content_patterns | ファイル: `*.py`, `*.ts`, `*.tsx` / コンテンツ: `class\s+\w+`, `interface\s+\w+`, `type\s+\w+\s*=` |
+| comment-analyzer | content_patterns | `"""`, `'''`, `/\*\*`, `//\s*TODO`, `#\s*TODO` |
+| code-simplifier | `always = true` | - |
+
+(load-error)=
+## LoadError（読み込みエラー）
+
+エージェント定義ファイルの読み込み時に発生したエラー情報を保持します。
+読み込みに失敗した個別のエージェント定義はスキップされ、他のエージェントの読み込みは継続します。
+
+| フィールド | 型 | 制約 |
+|-----------|---|------|
+| `source` | `str` | 空文字列不可。エラー発生元（ファイルパス等） |
+| `message` | `str` | 空文字列不可。エラーメッセージ |
+
+## LoadResult（読み込み結果）
+
+エージェント定義の読み込み結果です。
+正常に読み込まれた定義とスキップされたエラー情報を分離して保持します。
+
+| フィールド | 型 | 制約 |
+|-----------|---|------|
+| `agents` | `tuple[AgentDefinition, ...]` | 読み込み成功したエージェント定義 |
+| `errors` | `tuple[LoadError, ...]` | デフォルト空タプル。読み込みエラー情報 |
+
+## エージェントの読み込み
+
+### load_builtin_agents()
+
+パッケージに同梱された6つのビルトインエージェント定義を読み込みます。
+
+```{code-block} python
+from hachimoku.agents import load_builtin_agents
+
+result = load_builtin_agents()
+print(len(result.agents))  # 6
+```
+
+### load_custom_agents(custom_dir)
+
+指定ディレクトリ内の `*.toml` ファイルをカスタムエージェント定義として読み込みます。
+ディレクトリが存在しない場合は空の LoadResult を返します。
+
+```{code-block} python
+from pathlib import Path
+from hachimoku.agents import load_custom_agents
+
+result = load_custom_agents(Path(".hachimoku/agents"))
+```
+
+### load_agents(custom_dir=None)
+
+ビルトインとカスタムのエージェント定義を統合して読み込みます。
+カスタム定義がビルトインと同名の場合、カスタムがビルトインを上書きします。
+
+```{code-block} python
+from pathlib import Path
+from hachimoku.agents import load_agents
+
+# ビルトインのみ
+result = load_agents()
+
+# カスタムと統合
+result = load_agents(custom_dir=Path(".hachimoku/agents"))
+
+for agent in result.agents:
+    print(f"{agent.name}: {agent.description}")
+
+# 読み込みエラーの確認
+for error in result.errors:
+    print(f"Skipped {error.source}: {error.message}")
+```
+
+## カスタムエージェントの作成
+
+プロジェクト固有のカスタムエージェントを追加する手順:
+
+1. `.hachimoku/agents/` ディレクトリを作成
+2. TOML 形式でエージェント定義ファイルを配置
+
+```{code-block} toml
+:caption: .hachimoku/agents/security-checker.toml
+
+name = "security-checker"
+description = "セキュリティ脆弱性の検出"
+model = "claude-sonnet-4-5-20250929"
+output_schema = "scored_issues"
+system_prompt = """
+You are a security specialist. Analyze the code for vulnerabilities.
+"""
+
+[applicability]
+always = true
+```
+
+`output_schema` には [SCHEMA_REGISTRY](schema-registry) に登録されたスキーマ名を指定します。
+ビルトインと同名のファイルを配置すると、ビルトインの定義を上書きできます。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,157 @@
+# 設定
+
+hachimoku は TOML ベースの階層的な設定システムを提供します。
+5つのソースから設定を読み込み、優先度に基づいて値を解決します。
+
+```{contents}
+:depth: 2
+:local:
+```
+
+## 設定の階層
+
+以下の5層で構成されます。上位のソースが下位を上書きします。
+
+1. CLI オプション（最高優先度）
+2. `.hachimoku/config.toml`（プロジェクト設定）
+3. `pyproject.toml` の `[tool.hachimoku]` セクション
+4. `~/.config/hachimoku/config.toml`（ユーザーグローバル設定）
+5. デフォルト値（最低優先度）
+
+プロジェクト設定（`.hachimoku/config.toml`）と `pyproject.toml` は、カレントディレクトリから親方向に探索されます。
+
+### マージルール
+
+- スカラー値: 高優先レイヤーの値が上書き
+- `agents` セクション: エージェント名をキーとしてフィールド単位でマージ
+- `selector` セクション: フィールド単位でマージ
+
+## 設定ファイル形式
+
+### .hachimoku/config.toml
+
+```{code-block} toml
+# 実行設定
+model = "sonnet"
+timeout = 300
+max_turns = 10
+parallel = true
+base_branch = "main"
+
+# 出力設定
+output_format = "markdown"  # "markdown" or "json"
+save_reviews = true
+show_cost = false
+
+# ファイルモード設定
+max_files_per_review = 100
+
+# セレクターエージェント設定
+[selector]
+model = "sonnet"
+timeout = 300
+max_turns = 10
+allowed_tools = ["git_read", "gh_read", "file_read"]
+
+# エージェント個別設定
+[agents.code-reviewer]
+enabled = true
+model = "sonnet"
+timeout = 600
+max_turns = 15
+
+[agents.comment-analyzer]
+enabled = false
+```
+
+### pyproject.toml
+
+```{code-block} toml
+[tool.hachimoku]
+model = "sonnet"
+timeout = 300
+parallel = false
+```
+
+## 設定項目
+
+### HachimokuConfig
+
+全設定項目の一覧です。
+
+| 項目 | 型 | デフォルト | 制約 | 説明 |
+|-----|---|----------|------|------|
+| `model` | `str` | `"sonnet"` | 空文字不可 | 使用する LLM モデル名 |
+| `timeout` | `int` | `300` | 正の値 | エージェントのタイムアウト（秒） |
+| `max_turns` | `int` | `10` | 正の値 | エージェントの最大ターン数 |
+| `parallel` | `bool` | `true` | - | 並列実行の有効化 |
+| `base_branch` | `str` | `"main"` | 空文字不可 | diff モードの基準ブランチ |
+| `output_format` | `str` | `"markdown"` | `"markdown"` or `"json"` | 出力形式 |
+| `save_reviews` | `bool` | `true` | - | レビュー履歴の保存 |
+| `show_cost` | `bool` | `false` | - | コスト情報の表示 |
+| `max_files_per_review` | `int` | `100` | 正の値 | file モードの最大ファイル数 |
+| `selector` | `SelectorConfig` | 後述 | - | セレクターエージェント設定 |
+| `agents` | `dict[str, AgentConfig]` | `{}` | - | エージェント個別設定 |
+
+### SelectorConfig
+
+セレクターエージェントの設定です。
+`model`、`timeout`、`max_turns` が `None` の場合はグローバル設定値を使用します。
+
+| 項目 | 型 | デフォルト | 制約 | 説明 |
+|-----|---|----------|------|------|
+| `model` | `str \| None` | `None` | 空文字不可 | モデル名 |
+| `timeout` | `int \| None` | `None` | 正の値 | タイムアウト（秒） |
+| `max_turns` | `int \| None` | `None` | 正の値 | 最大ターン数 |
+| `allowed_tools` | `list[`[ToolCategory](tool-category)`]` | 全3カテゴリ | 1要素以上 | 許可ツールカテゴリ |
+
+### AgentConfig
+
+エージェントごとの個別設定です。
+`model`、`timeout`、`max_turns` が `None` の場合はグローバル設定値を使用します。
+
+| 項目 | 型 | デフォルト | 制約 | 説明 |
+|-----|---|----------|------|------|
+| `enabled` | `bool` | `true` | - | エージェントの有効/無効 |
+| `model` | `str \| None` | `None` | 空文字不可 | モデル名 |
+| `timeout` | `int \| None` | `None` | 正の値 | タイムアウト（秒） |
+| `max_turns` | `int \| None` | `None` | 正の値 | 最大ターン数 |
+
+エージェント名は `[agents.<name>]` 形式で指定し、`^[a-z0-9-]+$` パターンに一致する必要があります。
+
+## プロジェクトルート探索
+
+`find_project_root()` は指定ディレクトリから親方向に `.hachimoku/` ディレクトリを探索します。
+見つからない場合は `None` を返します。
+
+```{code-block} python
+from pathlib import Path
+from hachimoku.config import find_project_root
+
+root = find_project_root(Path.cwd())
+if root is not None:
+    print(f"Project root: {root}")
+```
+
+## 設定の解決
+
+`resolve_config()` は5層の設定ソースを統合し、最終的な設定オブジェクトを構築します。
+全ファイルが存在しない場合はデフォルト値のみで構築されます。
+
+```{code-block} python
+from pathlib import Path
+from hachimoku.config import resolve_config
+
+# デフォルト設定（カレントディレクトリから探索）
+config = resolve_config()
+
+# 探索開始ディレクトリと CLI オーバーライドを指定
+config = resolve_config(
+    start_dir=Path("/path/to/project"),
+    cli_overrides={"timeout": 600, "parallel": False},
+)
+
+print(config.model)      # "sonnet"
+print(config.timeout)    # 600（CLI オーバーライドが適用）
+print(config.parallel)   # False（CLI オーバーライドが適用）
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ hachimoku（8moku）は、複数の専門エージェントを用いてコード
 - code-simplifier: コード簡潔化の提案
 
 エージェントは `.hachimoku/agents/` に TOML 形式で定義されており、プロジェクト固有のカスタムエージェントを追加できます。
+詳細は [エージェント定義](agents.md) を参照してください。
 
 ### 実行と出力
 
@@ -39,15 +40,19 @@ TOML ベースの階層的な設定をサポートします。
 
 - CLI オプション > `.hachimoku/config.toml` > `pyproject.toml [tool.hachimoku]` > `~/.config/hachimoku/config.toml` > デフォルト
 
+詳細は [設定](configuration.md) を参照してください。
+
 ### ドメインモデル
 
 レビュー結果は型安全なドメインモデルで管理されます。
-Severity（4段階重大度）、ReviewIssue（問題の統一表現）、AgentResult（判別共用体による成功/切り詰め/エラー/タイムアウト）、ReviewReport（結果集約レポート）を提供します。
+Severity（4段階重大度）、ReviewIssue（問題の統一表現）、AgentResult（判別共用体による成功/切り詰め/エラー/タイムアウト）、ReviewReport（結果集約レポート）、ToolCategory（ツールカテゴリ）、ReviewHistoryRecord（レビュー履歴レコード）を提供します。
 詳細は [ドメインモデル](models.md) を参照してください。
 
 ```{toctree}
 :maxdepth: 2
 :caption: Contents
 
+agents
+configuration
 models
 ```

--- a/docs/models.md
+++ b/docs/models.md
@@ -23,6 +23,25 @@ hachimoku のドメインモデルは `hachimoku.models` パッケージで定�
 
 ReviewIssue の severity フィールドでは、大文字小文字を区別せずに入力を受け付けます（`"critical"`, `"CRITICAL"`, `"Critical"` いずれも有効）。
 
+(tool-category)=
+## ToolCategory（ツールカテゴリ）
+
+エージェントに許可されるツールの種類を定義する列挙型（StrEnum）です。
+読み取り専用の3カテゴリで構成されます。
+
+| 値 | 文字列値 | 説明 |
+|----|---------|------|
+| `GIT_READ` | `"git_read"` | Git 読み取り操作（diff, log, show, status 等） |
+| `GH_READ` | `"gh_read"` | GitHub CLI 読み取り操作（pr view, issue view 等） |
+| `FILE_READ` | `"file_read"` | ファイル読み取り操作（read, ls 等） |
+
+```{code-block} python
+from hachimoku.models import ToolCategory
+
+cat = ToolCategory.GIT_READ
+assert cat == "git_read"
+```
+
 ## FileLocation（ファイル位置）
 
 レビュー問題が検出されたファイル内の位置を表します。
@@ -153,7 +172,9 @@ assert isinstance(result, AgentSuccess)
 |-----------|---|------|------|
 | `results` | `list[AgentResult]` | Yes | 空リスト許容 |
 | `summary` | `ReviewSummary` | Yes | - |
+| `load_errors` | `tuple[`[LoadError](load-error)`, ...]` | No | デフォルト空タプル |
 
+`load_errors` はエージェント定義の読み込み時に発生したエラーを保持します。
 全エージェントが失敗した場合でも空の `results` でレポートを生成できます。
 
 ```{code-block} python
@@ -169,6 +190,88 @@ report = ReviewReport(
 )
 ```
 
+## レビュー履歴レコード
+
+レビュー結果を JSONL 形式で永続化するためのレコードモデルです。
+`review_mode` フィールドの値で型が自動選択される判別共用体として定義されています。
+
+### CommitHash
+
+Git コミットハッシュの型エイリアスです。40文字の16進小文字文字列に制約されます。
+
+```{code-block} python
+from hachimoku.models import CommitHash
+from pydantic import TypeAdapter
+
+adapter = TypeAdapter(CommitHash)
+hash_value = adapter.validate_python("a" * 40)  # 有効
+```
+
+### DiffReviewRecord
+
+diff モードのレビュー履歴レコードです。
+
+| フィールド | 型 | 必須 | 制約 |
+|-----------|---|------|------|
+| `review_mode` | `Literal["diff"]` | Yes | 固定値 `"diff"` |
+| `commit_hash` | `CommitHash` | Yes | 40文字の16進小文字 |
+| `branch_name` | `str` | Yes | 空文字列不可 |
+| `reviewed_at` | `datetime` | Yes | - |
+| `results` | `list[AgentResult]` | Yes | - |
+| `summary` | `ReviewSummary` | Yes | - |
+
+### PRReviewRecord
+
+PR モードのレビュー履歴レコードです。
+
+| フィールド | 型 | 必須 | 制約 |
+|-----------|---|------|------|
+| `review_mode` | `Literal["pr"]` | Yes | 固定値 `"pr"` |
+| `commit_hash` | `CommitHash` | Yes | 40文字の16進小文字 |
+| `pr_number` | `int` | Yes | 1以上 |
+| `branch_name` | `str` | Yes | 空文字列不可 |
+| `reviewed_at` | `datetime` | Yes | - |
+| `results` | `list[AgentResult]` | Yes | - |
+| `summary` | `ReviewSummary` | Yes | - |
+
+### FileReviewRecord
+
+file モードのレビュー履歴レコードです。
+
+| フィールド | 型 | 必須 | 制約 |
+|-----------|---|------|------|
+| `review_mode` | `Literal["file"]` | Yes | 固定値 `"file"` |
+| `file_paths` | `frozenset[str]` | Yes | 1要素以上、各要素非空 |
+| `reviewed_at` | `datetime` | Yes | - |
+| `working_directory` | `str` | Yes | 絶対パス |
+| `results` | `list[AgentResult]` | Yes | - |
+| `summary` | `ReviewSummary` | Yes | - |
+
+### デシリアライズ例
+
+```{code-block} python
+from pydantic import TypeAdapter
+from hachimoku.models import ReviewHistoryRecord, DiffReviewRecord
+
+adapter = TypeAdapter(ReviewHistoryRecord)
+
+# review_mode フィールドで型が自動選択される
+record = adapter.validate_python({
+    "review_mode": "diff",
+    "commit_hash": "a" * 40,
+    "branch_name": "feature/example",
+    "reviewed_at": "2026-01-01T00:00:00",
+    "results": [],
+    "summary": {
+        "total_issues": 0,
+        "max_severity": None,
+        "total_elapsed_time": 0.0,
+    },
+})
+assert isinstance(record, DiffReviewRecord)
+```
+
+(output-schemas)=
 ## 出力スキーマ
 
 エージェントの出力形式を規定するスキーマです。全スキーマは `BaseAgentOutput` を継承し、共通属性として `issues: list[ReviewIssue]` を持ちます。
@@ -301,6 +404,7 @@ ImprovementItem は以下のフィールドを持ちます。
 | `priority` | `Severity` | Yes | - |
 | `location` | `FileLocation \| None` | No | デフォルト `None` |
 
+(schema-registry)=
 ## SCHEMA_REGISTRY（スキーマレジストリ）
 
 スキーマ名から対応するスキーマクラスを解決するレジストリです。エージェント定義ファイルの `output_schema` フィールドからスキーマを特定する際に使用します。


### PR DESCRIPTION
## Summary

- agents.md 新規作成: ビルトイン6エージェント、TOML定義形式、Phase、ApplicabilityRule、LoadError/LoadResult、ローダー関数、カスタムエージェント作成手順
- configuration.md 新規作成: 5層設定階層、HachimokuConfig/SelectorConfig/AgentConfig、設定ファイル形式、マージルール、find_project_root、resolve_config
- models.md 更新: ToolCategory、ReviewReport.load_errors、レビュー履歴レコード追加、クロスリファレンスターゲット設置
- index.md 更新: toctree 拡張、各セクションへのリンク追加

## Test plan

- [ ] `make -C docs clean html` でエラー・警告なしを確認
- [ ] クロスリファレンス（load-error, tool-category, output-schemas, schema-registry）が正常にリンク解決されること
- [ ] 生成された HTML を `docs/_build/html/index.html` から確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)