### PR TITLE
feat(#97): 並列 executor のシグナル受信時 TaskGroup 即座キャンセル

### DIFF
--- a/src/hachimoku/engine/_executor.py
+++ b/src/hachimoku/engine/_executor.py
@@ -134,11 +134,11 @@ async def execute_parallel(
             except Exception:
                 pass
             result = await run_agent(ctx)
+            results.append(result)
             try:
                 report_agent_complete(ctx.agent_name, result)
             except Exception:
                 pass
-            results.append(result)
 
         async def _run_phase() -> None:
             """フェーズ内の全エージェントを TaskGroup で並列実行する。"""


### PR DESCRIPTION
## Summary

- `execute_parallel` にフェーズ単位のシャットダウン監視を追加し、`shutdown_event` セット時に `phase_task.cancel()` で TaskGroup 内の実行中タスクを即座にキャンセルする
- 従来の `_run_and_collect` 先頭のポーリングチェックに加え、`asyncio.wait(FIRST_COMPLETED)` で shutdown_event とフェーズタスクを競合させる能動的キャンセル機構を実装
- `_engine.py` の `_execute_with_shutdown_timeout` と同じアーキテクチャパターンをフェーズ単位で適用

## Test plan

- [x] `test_shutdown_cancels_phase_and_preserves_completed` — 完了済みエージェントの結果が保持され、未完了がキャンセルされる
- [x] `test_shutdown_cancels_running_tasks_immediately` — 10秒 sleep が 1秒未満でキャンセルされる（能動的キャンセルの証拠）
- [x] `test_shutdown_preserves_completed_results_in_cancelled_phase` — collected_results に部分結果が保存される
- [x] `test_shutdown_skips_subsequent_phases_after_cancellation` — キャンセル後の後続フェーズがスキップされる
- [x] `test_no_shutdown_sentinel_does_not_affect_normal_execution` — シャットダウンなしの正常動作に影響なし
- [x] 既存テスト 856 件全通過
- [x] ruff check / ruff format / mypy 全通過

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)