### PR TITLE
feat(#105): agents サブコマンドと最終品質改善（US5 + Polish）

### DIFF
--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -49,18 +49,23 @@ def make_agent_definition(
     phase: str = "main",
     output_schema: str = "scored_issues",
     description: str = "Test agent description",
+    system_prompt: str = "Test system prompt for testing purposes.",
+    applicability: dict[str, object] | None = None,
+    allowed_tools: tuple[str, ...] = (),
 ) -> AgentDefinition:
     """テスト用の最小 AgentDefinition を生成する。"""
-    return AgentDefinition.model_validate(
-        {
-            "name": name,
-            "description": description,
-            "model": model,
-            "output_schema": output_schema,
-            "system_prompt": "Test system prompt for testing purposes.",
-            "phase": phase,
-        }
-    )
+    data: dict[str, object] = {
+        "name": name,
+        "description": description,
+        "model": model,
+        "output_schema": output_schema,
+        "system_prompt": system_prompt,
+        "phase": phase,
+        "allowed_tools": allowed_tools,
+    }
+    if applicability is not None:
+        data["applicability"] = applicability
+    return AgentDefinition.model_validate(data)
 
 
 def make_load_result(


### PR DESCRIPTION
## Summary

- `8moku agents` でエージェント一覧をテーブル形式で表示、`8moku agents <name>` で詳細情報を表示する agents サブコマンドを実装（FR-CLI-012）
- カスタムエージェントに `[custom]` マーカーを付与し、存在しないエージェント名には解決方法ヒント付きエラーを返却（FR-CLI-014）
- エッジケーステスト 14 件追加：PR番号+ファイルパス混在、サブコマンド名衝突（`init`/`agents` vs `./init`/`./agents`）、`--format`/`--timeout`/`--issue` 不正値、Git リポジトリ外での diff/PR モード
- `run_review()` 例外メッセージに解決方法ヒントを追加し、全エラーパスで FR-CLI-014 準拠を確保

## Test plan

- [x] `TestAgentsSubcommand`: 13 テスト（一覧表示、詳細表示、カスタムマーカー、存在しないエージェント、読み込みエラー警告）
- [x] `TestEdgeCases`: 14 テスト（入力混在、サブコマンド名衝突、バリデーション、Git リポジトリチェック）
- [x] `TestReviewRunReviewError`: ヒント検証テスト追加
- [x] 全 1127 テスト passed
- [x] `ruff check --fix . && ruff format . && mypy .` エラーなし

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)