### PR TITLE
fix(#120): モデル名を pydantic-ai の anthropic:model-id 形式に統一

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -49,7 +49,7 @@ hachimoku のレビューエージェントは TOML ファイルで定義され�
 
 1. `[selector]` 設定の `model`（[設定](configuration.md) 参照）
 2. セレクター定義の `model`
-3. グローバル設定の `model`（デフォルト: `"sonnet"`）
+3. グローバル設定の `model`（デフォルト: `"anthropic:claude-sonnet-4-5"`）
 
 ### ビルトインセレクター定義
 
@@ -61,7 +61,7 @@ hachimoku のレビューエージェントは TOML ファイルで定義され�
 
 name = "selector"
 description = "レビュー対象を分析し、実行すべきレビューエージェントを選択する"
-model = "claude-haiku-4-5-20251001"
+model = "anthropic:claude-haiku-4-5"
 allowed_tools = ["git_read", "gh_read", "file_read"]
 system_prompt = """
 You are an agent selector for code review.
@@ -117,7 +117,7 @@ print(definition.name)  # "selector"
 ```{code-block} toml
 name = "code-reviewer"
 description = "コード品質・バグ・ベストプラクティスの総合レビュー"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "scored_issues"
 phase = "main"
 allowed_tools = ["git_read", "gh_read", "file_read"]
@@ -280,7 +280,7 @@ for error in result.errors:
 
 name = "security-checker"
 description = "セキュリティ脆弱性の検出"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "scored_issues"
 allowed_tools = ["git_read", "gh_read", "file_read"]
 system_prompt = """

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ hachimoku は TOML ベースの階層的な設定システムを提供します�
 
 ```{code-block} toml
 # 実行設定
-model = "sonnet"
+model = "anthropic:claude-sonnet-4-5"
 timeout = 300
 max_turns = 10
 parallel = true
@@ -48,14 +48,14 @@ max_files_per_review = 100
 
 # セレクターエージェント設定
 [selector]
-model = "sonnet"
+model = "anthropic:claude-haiku-4-5"
 timeout = 300
 max_turns = 10
 
 # エージェント個別設定
 [agents.code-reviewer]
 enabled = true
-model = "sonnet"
+model = "anthropic:claude-sonnet-4-5"
 timeout = 600
 max_turns = 15
 
@@ -67,7 +67,7 @@ enabled = false
 
 ```{code-block} toml
 [tool.hachimoku]
-model = "sonnet"
+model = "anthropic:claude-sonnet-4-5"
 timeout = 300
 parallel = false
 ```
@@ -80,7 +80,7 @@ parallel = false
 
 | 項目 | 型 | デフォルト | 制約 | 説明 |
 |-----|---|----------|------|------|
-| `model` | `str` | `"sonnet"` | 空文字不可 | 使用する LLM モデル名 |
+| `model` | `str` | `"anthropic:claude-sonnet-4-5"` | 空文字不可 | 使用する LLM モデル名 |
 | `timeout` | `int` | `300` | 正の値 | エージェントのタイムアウト（秒） |
 | `max_turns` | `int` | `10` | 正の値 | エージェントの最大ターン数 |
 | `parallel` | `bool` | `true` | - | 並列実行の有効化 |
@@ -149,7 +149,7 @@ config = resolve_config(
     cli_overrides={"timeout": 600, "parallel": False},
 )
 
-print(config.model)      # "sonnet"
+print(config.model)      # "anthropic:claude-sonnet-4-5"
 print(config.timeout)    # 600（CLI オーバーライドが適用）
 print(config.parallel)   # False（CLI オーバーライドが適用）
 ```

--- a/specs/003-agent-definition/data-model.md
+++ b/specs/003-agent-definition/data-model.md
@@ -111,7 +111,7 @@ erDiagram
 ```toml
 name = "code-reviewer"
 description = "コード品質・バグ・ベストプラクティスのレビュー"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "scored_issues"
 system_prompt = """
 You are code-reviewer, an expert code quality analyst...
@@ -198,7 +198,7 @@ always = true
 # 必須フィールド
 name = "agent-name"                    # ^[a-z0-9-]+$
 description = "エージェントの説明"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "scored_issues"        # SCHEMA_REGISTRY 登録名
 system_prompt = """
 システムプロンプトの内容

--- a/specs/003-agent-definition/quickstart.md
+++ b/specs/003-agent-definition/quickstart.md
@@ -64,7 +64,7 @@ for error in result.errors:
 # .hachimoku/agents/security-reviewer.toml
 name = "security-reviewer"
 description = "セキュリティ脆弱性の検出"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "scored_issues"
 system_prompt = """
 You are a security review specialist. Focus on:

--- a/specs/004-configuration/contracts/config_models.py
+++ b/specs/004-configuration/contracts/config_models.py
@@ -47,7 +47,7 @@ class HachimokuConfig(HachimokuBaseModel):
     """
 
     # 実行設定
-    model: str = Field(default="sonnet", min_length=1)
+    model: str = Field(default="anthropic:claude-sonnet-4-5", min_length=1)
     timeout: int = Field(default=300, gt=0)
     max_turns: int = Field(default=10, gt=0)
     parallel: bool = True

--- a/specs/004-configuration/data-model.md
+++ b/specs/004-configuration/data-model.md
@@ -53,7 +53,7 @@
 
 | Field | Type | Default | Constraints | CLI Option | Description |
 |-------|------|---------|-------------|------------|-------------|
-| `model` | `str` | `"sonnet"` | `min_length=1` | `--model` | 使用する LLM モデル名 |
+| `model` | `str` | `"anthropic:claude-sonnet-4-5"` | `min_length=1` | `--model` | 使用する LLM モデル名 |
 | `timeout` | `int` | `300` | `> 0` | `--timeout` | エージェント実行タイムアウト（秒） |
 | `max_turns` | `int` | `10` | `> 0` | `--max-turns` | エージェント最大ターン数 |
 | `parallel` | `bool` | `True` | - | `--parallel` | 並列実行モード |

--- a/specs/004-configuration/quickstart.md
+++ b/specs/004-configuration/quickstart.md
@@ -15,7 +15,7 @@ from hachimoku.config import resolve_config
 
 # 全項目がデフォルト値で構成される
 config = resolve_config()
-assert config.model == "sonnet"
+assert config.model == "anthropic:claude-sonnet-4-5"
 assert config.timeout == 300
 assert config.parallel is True
 ```

--- a/specs/004-configuration/spec.md
+++ b/specs/004-configuration/spec.md
@@ -47,7 +47,7 @@
 2. **Given** `.hachimoku/config.toml` に `base_branch = "develop"` が設定されている, **When** 設定を解決する, **Then** `base_branch` の値が `"develop"` に解決され、他の項目はデフォルト値が適用される
 3. **Given** `.hachimoku/config.toml` と `pyproject.toml [tool.hachimoku]` の両方に `base_branch` が設定されている, **When** 設定を解決する, **Then** `.hachimoku/config.toml` の値が優先される
 4. **Given** `~/.config/hachimoku/config.toml` にのみ設定がある状態, **When** 設定を解決する, **Then** ユーザーグローバル設定の値が適用される
-5. **Given** CLI オプションで `--model sonnet` が指定され、`.hachimoku/config.toml` に `model = "opus"` が設定されている, **When** 設定を解決する, **Then** CLI オプションの `"sonnet"` が優先される
+5. **Given** CLI オプションで `--model anthropic:claude-sonnet-4-5` が指定され、`.hachimoku/config.toml` に `model = "anthropic:claude-opus-4-6"` が設定されている, **When** 設定を解決する, **Then** CLI オプションの `"anthropic:claude-sonnet-4-5"` が優先される
 6. **Given** `pyproject.toml` に `[tool.hachimoku]` セクションが存在しない, **When** 設定を解決する, **Then** `pyproject.toml` の設定ソースはスキップされ、他のソースから解決される
 
 ---
@@ -149,7 +149,7 @@
 
   | 設定キー | CLI オプション | デフォルト | 型・制約 |
   |---------|--------------|----------|---------|
-  | `model` | `--model` | `"sonnet"` | 文字列 |
+  | `model` | `--model` | `"anthropic:claude-sonnet-4-5"` | 文字列 |
   | `timeout` | `--timeout` | `300` | 正の整数 |
   | `max_turns` | `--max-turns` | `10` | 正の整数 |
   | `parallel` | `--parallel` | `true` | boolean |

--- a/specs/004-configuration/tasks.md
+++ b/specs/004-configuration/tasks.md
@@ -41,7 +41,7 @@
   - extra="forbid" (未知キー拒否)
 - [ ] T005 [P] Write tests for `HachimokuConfig` model in `tests/unit/models/test_config.py`:
   - デフォルト値のみでインスタンス構築可能
-  - 各フィールドのデフォルト値（model="sonnet", timeout=300, max_turns=10, parallel=True, base_branch="main", output_format=MARKDOWN, save_reviews=True, show_cost=False, max_files_per_review=100, agents={})
+  - 各フィールドのデフォルト値（model="anthropic:claude-sonnet-4-5", timeout=300, max_turns=10, parallel=True, base_branch="main", output_format=MARKDOWN, save_reviews=True, show_cost=False, max_files_per_review=100, agents={})
   - バリデーション: timeout/max_turns/max_files_per_review > 0, model/base_branch min_length=1, output_format enum, parallel に非 boolean 値（例: 文字列 "abc"）で ValidationError
   - agents キーの名前パターン検証（`^[a-z0-9-]+$`、不正名でエラー）
   - extra="forbid": 未知キー拒否で `ValidationError`（`match=` で未知キー名を含むことを検証）

--- a/specs/005-review-engine/data-model.md
+++ b/specs/005-review-engine/data-model.md
@@ -168,13 +168,13 @@ ReviewEngine
 AgentDefinition.model ──┐
 AgentConfig.model ──────┤  ← 個別設定が最優先
 HachimokuConfig.model ──┤  ← グローバル設定
-(default: "sonnet") ────┘  ← HachimokuConfig のデフォルト値
+(default: "anthropic:claude-sonnet-4-5") ────┘  ← HachimokuConfig のデフォルト値
 
 同様に timeout, max_turns も解決:
   AgentConfig.X > HachimokuConfig.X > HachimokuConfig デフォルト値
 
 セレクターのモデル解決:
-  SelectorConfig.model > SelectorDefinition.model > HachimokuConfig.model > default("sonnet")
+  SelectorConfig.model > SelectorDefinition.model > HachimokuConfig.model > default("anthropic:claude-sonnet-4-5")
 
 セレクターの allowed_tools:
   SelectorDefinition.allowed_tools のみ（SelectorConfig からは削除済み）

--- a/specs/006-cli-interface/spec.md
+++ b/specs/006-cli-interface/spec.md
@@ -64,7 +64,7 @@ CLI がレビュー実行を 005-review-engine に委譲し、結果を stdout �
 3. **Given** レビュー結果に問題がない状態, **When** レビューが完了する, **Then** 終了コード 0 が返される
 4. **Given** 全エージェントが実行失敗した状態, **When** レビューが完了する, **Then** 終了コード 3 が返される
 5. **Given** `8moku > result.md` のようにリダイレクトする状態, **When** レビューが完了する, **Then** `result.md` にはレビューレポートのみが含まれ、進捗情報は含まれない
-6. **Given** CLI オプション `--model sonnet --timeout 600` を指定する状態, **When** レビューを実行する, **Then** CLI オプションの値が設定階層の最高優先として適用される
+6. **Given** CLI オプション `--model anthropic:claude-sonnet-4-5 --timeout 600` を指定する状態, **When** レビューを実行する, **Then** CLI オプションの値が設定階層の最高優先として適用される
 7. **Given** `--format json` を指定する状態, **When** レビューが完了する, **Then** JSON 形式のレビューレポートが stdout に出力される
 8. **Given** diff モードで `--issue 122` を指定する状態, **When** `8moku --issue 122` を実行, **Then** diff レビューに Issue #122 のコンテキストが含まれる
 9. **Given** PR モードで `--issue 50` を指定する状態, **When** `8moku 123 --issue 50` を実行, **Then** PR #123 のレビューに Issue #50 のコンテキストが含まれる

--- a/src/hachimoku/agents/_builtin/code-reviewer.toml
+++ b/src/hachimoku/agents/_builtin/code-reviewer.toml
@@ -1,6 +1,6 @@
 name = "code-reviewer"
 description = "コード品質・バグ・ベストプラクティスの総合レビュー"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "scored_issues"
 phase = "main"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/agents/_builtin/code-simplifier.toml
+++ b/src/hachimoku/agents/_builtin/code-simplifier.toml
@@ -1,6 +1,6 @@
 name = "code-simplifier"
 description = "コードの簡潔化・改善提案"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "improvement_suggestions"
 phase = "final"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/agents/_builtin/comment-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/comment-analyzer.toml
@@ -1,6 +1,6 @@
 name = "comment-analyzer"
 description = "コードコメントの正確性・品質の分析"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "category_classification"
 phase = "final"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
@@ -1,6 +1,6 @@
 name = "pr-test-analyzer"
 description = "テストカバレッジの欠落・テスト品質の分析"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "test_gap_assessment"
 phase = "main"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
+++ b/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
@@ -1,6 +1,6 @@
 name = "silent-failure-hunter"
 description = "サイレント障害・エラーハンドリング不備の検出"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "severity_classified"
 phase = "main"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/agents/_builtin/type-design-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/type-design-analyzer.toml
@@ -1,6 +1,6 @@
 name = "type-design-analyzer"
 description = "型設計・インターフェース設計の分析"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "multi_dimensional_analysis"
 phase = "main"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/cli/_init_handler.py
+++ b/src/hachimoku/cli/_init_handler.py
@@ -40,7 +40,7 @@ _CONFIG_TEMPLATE: str = """\
 # --- Execution Settings ---
 
 # LLM model name
-# model = "sonnet"
+# model = "anthropic:claude-sonnet-4-5"
 
 # Timeout in seconds
 # timeout = 300
@@ -73,7 +73,7 @@ _CONFIG_TEMPLATE: str = """\
 # --- Selector Agent Settings ---
 
 # [selector]
-# model = "sonnet"
+# model = "anthropic:claude-sonnet-4-5"
 # timeout = 300
 # max_turns = 10
 # allowed_tools = ["git_read", "gh_read", "file_read"]
@@ -84,7 +84,7 @@ _CONFIG_TEMPLATE: str = """\
 #
 # [agents.code-reviewer]
 # enabled = true
-# model = "sonnet"
+# model = "anthropic:claude-sonnet-4-5"
 # timeout = 300
 # max_turns = 10
 """

--- a/src/hachimoku/models/config.py
+++ b/src/hachimoku/models/config.py
@@ -70,7 +70,7 @@ class HachimokuConfig(HachimokuBaseModel):
     """
 
     # 実行設定
-    model: str = Field(default="sonnet", min_length=1)
+    model: str = Field(default="anthropic:claude-sonnet-4-5", min_length=1)
     timeout: int = Field(default=300, gt=0)
     max_turns: int = Field(default=10, gt=0)
     parallel: StrictBool = True

--- a/tests/unit/agents/test_loader.py
+++ b/tests/unit/agents/test_loader.py
@@ -35,7 +35,7 @@ from hachimoku.agents.models import AgentDefinition, LoadResult, Phase
 VALID_TOML = """\
 name = "test-agent"
 description = "A test agent"
-model = "claude-sonnet-4-5-20250929"
+model = "anthropic:claude-sonnet-4-5"
 output_schema = "scored_issues"
 system_prompt = "You are a test agent."
 """
@@ -104,7 +104,7 @@ class TestLoadSingleAgentValid:
         agent = _load_single_agent(path)
         assert agent.name == "test-agent"
         assert agent.description == "A test agent"
-        assert agent.model == "claude-sonnet-4-5-20250929"
+        assert agent.model == "anthropic:claude-sonnet-4-5"
         assert agent.output_schema == "scored_issues"
         assert agent.system_prompt == "You are a test agent."
 

--- a/tests/unit/cli/test_init_handler.py
+++ b/tests/unit/cli/test_init_handler.py
@@ -149,7 +149,7 @@ class TestGenerateConfigTemplate:
     def test_contains_default_values(self) -> None:
         """デフォルト値が含まれている。"""
         template = _generate_config_template()
-        assert '"sonnet"' in template
+        assert '"anthropic:claude-sonnet-4-5"' in template
         assert "300" in template
         assert "10" in template
         assert "true" in template

--- a/tests/unit/engine/test_context.py
+++ b/tests/unit/engine/test_context.py
@@ -550,7 +550,7 @@ class TestBuildExecutionContextPhaseVariants:
             user_message="msg",
             resolved_tools=(),
         )
-        assert ctx.model == "sonnet"
+        assert ctx.model == "anthropic:claude-sonnet-4-5"
         assert ctx.timeout_seconds == 300
         assert ctx.max_turns == 10
 

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -166,7 +166,7 @@ class TestHachimokuConfigDefaults:
         assert config is not None
 
     def test_default_model(self) -> None:
-        assert HachimokuConfig().model == "sonnet"
+        assert HachimokuConfig().model == "anthropic:claude-sonnet-4-5"
 
     def test_default_timeout(self) -> None:
         assert HachimokuConfig().timeout == 300


### PR DESCRIPTION
## Summary

- `HachimokuConfig.model` のデフォルト値 `"sonnet"` → `"anthropic:claude-sonnet-4-5"` に修正
- ビルトイン TOML 6ファイルのモデル名を `"anthropic:claude-sonnet-4-5"` に統一
- コンフィグテンプレート（`_init_handler.py`）のモデル名を更新
- ドキュメント（`docs/configuration.md`, `docs/agents.md`）のモデル名を更新
- 仕様書（`specs/003`, `004`, `005`, `006`）のモデル名・デフォルト値を更新
- 関連テストの期待値を更新（全1161テストパス）

## Test plan

- [x] `uv run pytest` — 全1161テストパス
- [x] `ruff check --fix . && ruff format . && mypy .` — 全品質チェックパス
- [x] `src/`, `docs/`, `specs/` に旧形式モデル名（`"sonnet"`, `"claude-sonnet-4-5-20250929"`, `"claude-haiku-4-5-20251001"`）の残存がないことを grep で確認

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)