### PR TITLE
fix(#128): ClaudeCodeModel の内部ターン制限に max_turns を渡す

### DIFF
--- a/src/hachimoku/engine/_runner.py
+++ b/src/hachimoku/engine/_runner.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 import asyncio
 import time
 
-from claudecode_model import ClaudeCodeModel
+from claudecode_model import ClaudeCodeModel, ClaudeCodeModelSettings
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import UsageLimitExceeded
-from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import UsageLimits
 
 from hachimoku.engine._context import AgentExecutionContext
@@ -75,9 +74,7 @@ async def run_agent(context: AgentExecutionContext) -> AgentResult:
             result = await agent.run(
                 context.user_message,
                 usage_limits=UsageLimits(request_limit=context.max_turns),
-                # ClaudeCodeModel の内部ターン制限を設定。
-                # ModelSettings TypedDict に max_turns は未定義のためキャスト。
-                model_settings=ModelSettings(max_turns=context.max_turns),  # type: ignore[typeddict-unknown-key]
+                model_settings=ClaudeCodeModelSettings(max_turns=context.max_turns),
             )
 
         elapsed = time.monotonic() - start_time

--- a/src/hachimoku/engine/_selector.py
+++ b/src/hachimoku/engine/_selector.py
@@ -11,9 +11,8 @@ import asyncio
 from collections.abc import Sequence
 from typing import Final
 
-from claudecode_model import ClaudeCodeModel
+from claudecode_model import ClaudeCodeModel, ClaudeCodeModelSettings
 from pydantic_ai import Agent
-from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import UsageLimits
 
 from hachimoku.agents.models import AgentDefinition
@@ -129,9 +128,7 @@ async def run_selector(
             result = await agent.run(
                 user_message,
                 usage_limits=UsageLimits(request_limit=max_turns),
-                # ClaudeCodeModel の内部ターン制限を設定。
-                # ModelSettings TypedDict に max_turns は未定義のためキャスト。
-                model_settings=ModelSettings(max_turns=max_turns),  # type: ignore[typeddict-unknown-key]
+                model_settings=ClaudeCodeModelSettings(max_turns=max_turns),
             )
 
         return result.output

--- a/tests/unit/engine/test_runner.py
+++ b/tests/unit/engine/test_runner.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from claudecode_model import ClaudeCodeModel
 from pydantic import ValidationError
 from pydantic_ai import Tool
+from pydantic_ai.usage import UsageLimits
 
 from hachimoku.agents.models import Phase
 from hachimoku.engine._context import AgentExecutionContext
@@ -390,3 +391,4 @@ class TestRunAgentModelSettings:
 
         call_kwargs = mock_instance.run.call_args.kwargs
         assert call_kwargs["model_settings"] == {"max_turns": 10}
+        assert call_kwargs["usage_limits"] == UsageLimits(request_limit=10)

--- a/tests/unit/engine/test_selector.py
+++ b/tests/unit/engine/test_selector.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from claudecode_model import ClaudeCodeModel
+from pydantic_ai.usage import UsageLimits
 
 from hachimoku.agents.models import AgentDefinition, ApplicabilityRule, Phase
 from hachimoku.engine._selector import SelectorError, SelectorOutput, run_selector
@@ -503,6 +504,7 @@ class TestRunSelectorModelSettings:
 
         call_kwargs = mock_instance.run.call_args.kwargs
         assert call_kwargs["model_settings"] == {"max_turns": 10}
+        assert call_kwargs["usage_limits"] == UsageLimits(request_limit=10)
 
     @patch("hachimoku.engine._selector.resolve_model", side_effect=lambda m, p: m)
     @patch("hachimoku.engine._selector.Agent")


### PR DESCRIPTION
## Summary

- `agent.run()` に `model_settings={"max_turns": N}` を追加し、ClaudeCodeModel の内部ターン制限を hachimoku の設定値で制御
- セレクターエージェント (`_selector.py`) とレビューエージェント (`_runner.py`) の両方に適用

## Background

ClaudeCodeModel は `json_schema` 存在時（構造化出力要求時）に内部デフォルト `DEFAULT_MAX_TURNS_WITH_JSON_SCHEMA = 3` を適用する。hachimoku の `max_turns` 設定（デフォルト10）は `UsageLimits(request_limit=N)` にのみ渡されており、ClaudeCodeModel の内部制限には届いていなかった。

セレクターエージェントが3ターンすべてをツール呼び出し（`git merge-base` → `git diff --stat` → `git diff`）に消費し、構造化出力を返すターンが残らず `error_max_turns` で失敗していた。

## Test plan

- [x] `TestRunSelectorModelSettings::test_model_settings_max_turns_passed` — グローバル max_turns が model_settings に渡される
- [x] `TestRunSelectorModelSettings::test_selector_config_max_turns_override` — SelectorConfig の max_turns が優先される
- [x] `TestRunAgentModelSettings::test_model_settings_max_turns_passed` — レビューエージェントにも model_settings が渡される
- [x] 全 1206 テスト通過、ruff + mypy エラーなし

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)