### PR TITLE
feat(#133): レビュー結果を JSONL 形式で .hachimoku/reviews/ に蓄積する

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,7 @@ parallel = false
 | `provider` | `str` | `"claudecode"` | `"claudecode"` or `"anthropic"` | LLM プロバイダー |
 | `base_branch` | `str` | `"main"` | 空文字不可 | diff モードの基準ブランチ |
 | `output_format` | `str` | `"markdown"` | `"markdown"` or `"json"` | 出力形式 |
-| `save_reviews` | `bool` | `true` | - | レビュー履歴の保存 |
+| `save_reviews` | `bool` | `true` | - | レビュー履歴の JSONL 保存（後述） |
 | `show_cost` | `bool` | `false` | - | コスト情報の表示 |
 | `max_files_per_review` | `int` | `100` | 正の値 | file モードの最大ファイル数 |
 | `selector` | `SelectorConfig` | 後述 | - | セレクターエージェント設定 |
@@ -122,6 +122,34 @@ parallel = false
 | `provider` | `str \| None` | `None` | `"claudecode"` or `"anthropic"` | プロバイダーの上書き |
 
 エージェント名は `[agents.<name>]` 形式で指定し、`^[a-z0-9-]+$` パターンに一致する必要があります。
+
+## レビュー履歴の蓄積
+
+`save_reviews = true`（デフォルト）の場合、レビュー完了後に結果を `.hachimoku/reviews/` ディレクトリへ JSONL 形式で自動蓄積します。
+
+### 蓄積先ファイル
+
+レビューモードごとに蓄積先ファイルが分かれます。
+
+| レビューモード | 蓄積先ファイル | 例 |
+|--------------|--------------|---|
+| diff | `diff.jsonl` | `.hachimoku/reviews/diff.jsonl` |
+| PR | `pr-{番号}.jsonl` | `.hachimoku/reviews/pr-123.jsonl` |
+| file | `files.jsonl` | `.hachimoku/reviews/files.jsonl` |
+
+各行は独立した JSON オブジェクトです。新しいレビューは既存ファイルに追記されます。
+
+### 無効化
+
+```{code-block} toml
+save_reviews = false
+```
+
+CLI オプションでも制御できます。
+
+```{code-block} bash
+8moku review --no-save-reviews
+```
 
 ## プロジェクトルート探索
 

--- a/src/hachimoku/cli/_history_writer.py
+++ b/src/hachimoku/cli/_history_writer.py
@@ -1,0 +1,220 @@
+"""HistoryWriter -- レビュー結果の JSONL 自動蓄積。
+
+FR-025: レビュー結果を .hachimoku/reviews/ に JSONL 形式で自動蓄積。
+FR-026: ReviewHistoryRecord の各バリアントを1行の JSON オブジェクトとして書き出す。
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final, assert_never
+
+from hachimoku.engine._target import DiffTarget, FileTarget, PRTarget
+from hachimoku.models.history import (
+    DiffReviewRecord,
+    FileReviewRecord,
+    PRReviewRecord,
+)
+from hachimoku.models.report import ReviewReport
+
+
+class HistoryWriteError(Exception):
+    """JSONL 書き込みエラー。ディレクトリ不在、I/O エラー等。"""
+
+
+class GitInfoError(Exception):
+    """git 情報取得エラー。git コマンド失敗等。"""
+
+
+_GIT_TIMEOUT_SECONDS: Final[int] = 5
+"""git コマンドのタイムアウト秒数。"""
+
+_DIFF_FILENAME: Final[str] = "diff.jsonl"
+_FILES_FILENAME: Final[str] = "files.jsonl"
+_PR_FILENAME_TEMPLATE: Final[str] = "pr-{pr_number}.jsonl"
+
+
+def _resolve_jsonl_path(
+    reviews_dir: Path,
+    target: DiffTarget | PRTarget | FileTarget,
+) -> Path:
+    """ターゲットに応じた JSONL ファイルパスを解決する。
+
+    Args:
+        reviews_dir: .hachimoku/reviews/ ディレクトリのパス。
+        target: レビュー対象。
+
+    Returns:
+        JSONL ファイルの絶対パス。
+    """
+    if isinstance(target, DiffTarget):
+        return reviews_dir / _DIFF_FILENAME
+    if isinstance(target, PRTarget):
+        return reviews_dir / _PR_FILENAME_TEMPLATE.format(pr_number=target.pr_number)
+    if isinstance(target, FileTarget):
+        return reviews_dir / _FILES_FILENAME
+    assert_never(target)
+
+
+def get_commit_hash() -> str:
+    """現在の HEAD コミットハッシュ（40文字16進小文字）を取得する。
+
+    Returns:
+        40文字のコミットハッシュ。
+
+    Raises:
+        GitInfoError: git コマンド失敗・未インストール・タイムアウト時。
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        raise GitInfoError(
+            "git command not found. Ensure git is installed and available in PATH."
+        ) from None
+    except subprocess.TimeoutExpired as exc:
+        raise GitInfoError(
+            f"git rev-parse timed out after {_GIT_TIMEOUT_SECONDS}s."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise GitInfoError(f"git rev-parse failed: {exc.stderr.strip()}") from exc
+    return result.stdout.strip()
+
+
+def get_branch_name() -> str:
+    """現在のブランチ名を取得する。
+
+    detached HEAD の場合は ``"HEAD"`` を返す。
+
+    Returns:
+        ブランチ名文字列。
+
+    Raises:
+        GitInfoError: git コマンド失敗・未インストール・タイムアウト時。
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        raise GitInfoError(
+            "git command not found. Ensure git is installed and available in PATH."
+        ) from None
+    except subprocess.TimeoutExpired as exc:
+        raise GitInfoError(
+            f"git rev-parse timed out after {_GIT_TIMEOUT_SECONDS}s."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise GitInfoError(f"git rev-parse failed: {exc.stderr.strip()}") from exc
+    return result.stdout.strip()
+
+
+def _build_record(
+    target: DiffTarget | PRTarget | FileTarget,
+    report: ReviewReport,
+    commit_hash: str,
+    branch_name: str,
+    reviewed_at: datetime,
+) -> DiffReviewRecord | PRReviewRecord | FileReviewRecord:
+    """ターゲットと結果から ReviewHistoryRecord バリアントを構築する。
+
+    Args:
+        target: レビュー対象。
+        report: レビューレポート。
+        commit_hash: コミットハッシュ（diff/PR モード用）。
+        branch_name: ブランチ名（diff/PR モード用）。
+        reviewed_at: レビュー実行日時。
+
+    Returns:
+        構築された ReviewHistoryRecord バリアント。
+    """
+    if isinstance(target, DiffTarget):
+        return DiffReviewRecord(
+            commit_hash=commit_hash,
+            branch_name=branch_name,
+            reviewed_at=reviewed_at,
+            results=report.results,
+            summary=report.summary,
+        )
+    if isinstance(target, PRTarget):
+        return PRReviewRecord(
+            commit_hash=commit_hash,
+            pr_number=target.pr_number,
+            branch_name=branch_name,
+            reviewed_at=reviewed_at,
+            results=report.results,
+            summary=report.summary,
+        )
+    if isinstance(target, FileTarget):
+        return FileReviewRecord(
+            file_paths=frozenset(target.paths),
+            reviewed_at=reviewed_at,
+            working_directory=str(Path.cwd()),
+            results=report.results,
+            summary=report.summary,
+        )
+    assert_never(target)
+
+
+def save_review_history(
+    reviews_dir: Path,
+    target: DiffTarget | PRTarget | FileTarget,
+    report: ReviewReport,
+) -> Path:
+    """レビュー結果を JSONL ファイルに追記する。
+
+    FR-025 のメインエントリポイント。
+    1. git 情報取得（diff/PR モードのみ）
+    2. ReviewHistoryRecord 構築
+    3. JSONL ファイルへの追記
+
+    Args:
+        reviews_dir: .hachimoku/reviews/ ディレクトリのパス。
+        target: レビュー対象。
+        report: レビューレポート。
+
+    Returns:
+        書き込み先 JSONL ファイルのパス。
+
+    Raises:
+        HistoryWriteError: ディレクトリ不在、I/O エラー時。
+        GitInfoError: git 情報取得失敗時（diff/PR モード）。
+    """
+    if not reviews_dir.is_dir():
+        raise HistoryWriteError(
+            f"Reviews directory does not exist: {reviews_dir}\n"
+            "Run '8moku init' to initialize the project structure."
+        )
+
+    commit_hash = ""
+    branch_name = ""
+    if isinstance(target, (DiffTarget, PRTarget)):
+        commit_hash = get_commit_hash()
+        branch_name = get_branch_name()
+
+    reviewed_at = datetime.now(timezone.utc)
+    record = _build_record(target, report, commit_hash, branch_name, reviewed_at)
+    jsonl_path = _resolve_jsonl_path(reviews_dir, target)
+
+    try:
+        with jsonl_path.open("a", encoding="utf-8") as f:
+            f.write(record.model_dump_json())
+            f.write("\n")
+    except OSError as exc:
+        raise HistoryWriteError(
+            f"Failed to write review history to {jsonl_path}: {exc}\n"
+            "Check file permissions and available disk space."
+        ) from exc
+
+    return jsonl_path

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from hachimoku.agents import AgentDefinition, LoadError, LoadResult
 from hachimoku.engine._engine import EngineResult
@@ -16,6 +20,14 @@ PATCH_RESOLVE_FILES = "hachimoku.cli._app.resolve_files"
 PATCH_LOAD_AGENTS = "hachimoku.cli._app.load_agents"
 PATCH_LOAD_BUILTIN_AGENTS = "hachimoku.cli._app.load_builtin_agents"
 PATCH_FIND_PROJECT_ROOT = "hachimoku.cli._app.find_project_root"
+PATCH_SAVE_REVIEW_HISTORY = "hachimoku.cli._history_writer.save_review_history"
+
+
+@pytest.fixture(autouse=True)
+def _prevent_review_history_writes() -> Iterator[None]:
+    """テストが実ファイルシステムにレビュー履歴を書き込むことを防止する。"""
+    with patch(PATCH_SAVE_REVIEW_HISTORY, return_value=Path("/dev/null")):
+        yield
 
 
 def make_engine_result(exit_code: ExitCode = ExitCode.SUCCESS) -> EngineResult:

--- a/tests/unit/cli/test_history_writer.py
+++ b/tests/unit/cli/test_history_writer.py
@@ -1,0 +1,369 @@
+"""_history_writer モジュールのテスト。
+
+FR-025: レビュー結果の JSONL 自動蓄積。
+FR-026: JSONL レコード形式。
+"""
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hachimoku.cli._history_writer import (
+    GitInfoError,
+    HistoryWriteError,
+    _build_record,
+    _resolve_jsonl_path,
+    get_branch_name,
+    get_commit_hash,
+    save_review_history,
+)
+from hachimoku.engine._target import DiffTarget, FileTarget, PRTarget
+from hachimoku.models.history import (
+    DiffReviewRecord,
+    FileReviewRecord,
+    PRReviewRecord,
+)
+from hachimoku.models.report import ReviewReport, ReviewSummary
+
+VALID_COMMIT_HASH = "a" * 40
+VALID_BRANCH_NAME = "feature/test"
+VALID_REVIEWED_AT = datetime(2026, 2, 9, 12, 0, 0, tzinfo=timezone.utc)
+VALID_SUMMARY = ReviewSummary(
+    total_issues=0,
+    max_severity=None,
+    total_elapsed_time=0.0,
+)
+
+
+def _make_report() -> ReviewReport:
+    """テスト用の空 ReviewReport を生成。"""
+    return ReviewReport(
+        results=[],
+        summary=VALID_SUMMARY,
+    )
+
+
+# =============================================================================
+# _resolve_jsonl_path
+# =============================================================================
+
+
+class TestResolveJsonlPath:
+    """_resolve_jsonl_path のファイルパス解決テスト。"""
+
+    def test_diff_target_returns_diff_jsonl(self, tmp_path: Path) -> None:
+        """DiffTarget → diff.jsonl。"""
+        target = DiffTarget(base_branch="main")
+        result = _resolve_jsonl_path(tmp_path, target)
+        assert result == tmp_path / "diff.jsonl"
+
+    def test_pr_target_returns_pr_number_jsonl(self, tmp_path: Path) -> None:
+        """PRTarget(pr_number=123) → pr-123.jsonl。"""
+        target = PRTarget(pr_number=123)
+        result = _resolve_jsonl_path(tmp_path, target)
+        assert result == tmp_path / "pr-123.jsonl"
+
+    def test_file_target_returns_files_jsonl(self, tmp_path: Path) -> None:
+        """FileTarget → files.jsonl。"""
+        target = FileTarget(paths=("src/main.py",))
+        result = _resolve_jsonl_path(tmp_path, target)
+        assert result == tmp_path / "files.jsonl"
+
+
+# =============================================================================
+# _build_record
+# =============================================================================
+
+
+class TestBuildRecord:
+    """_build_record の ReviewHistoryRecord 構築テスト。"""
+
+    def test_diff_target_builds_diff_record(self) -> None:
+        """DiffTarget → DiffReviewRecord が構築される。"""
+        target = DiffTarget(base_branch="main")
+        report = _make_report()
+        record = _build_record(
+            target, report, VALID_COMMIT_HASH, VALID_BRANCH_NAME, VALID_REVIEWED_AT
+        )
+        assert isinstance(record, DiffReviewRecord)
+        assert record.review_mode == "diff"
+        assert record.commit_hash == VALID_COMMIT_HASH
+        assert record.branch_name == VALID_BRANCH_NAME
+        assert record.reviewed_at == VALID_REVIEWED_AT
+        assert record.results == report.results
+        assert record.summary == report.summary
+
+    def test_pr_target_builds_pr_record(self) -> None:
+        """PRTarget → PRReviewRecord が構築される。"""
+        target = PRTarget(pr_number=42)
+        report = _make_report()
+        record = _build_record(
+            target, report, VALID_COMMIT_HASH, VALID_BRANCH_NAME, VALID_REVIEWED_AT
+        )
+        assert isinstance(record, PRReviewRecord)
+        assert record.review_mode == "pr"
+        assert record.pr_number == 42
+        assert record.commit_hash == VALID_COMMIT_HASH
+        assert record.branch_name == VALID_BRANCH_NAME
+
+    def test_file_target_builds_file_record(self) -> None:
+        """FileTarget → FileReviewRecord が構築される。"""
+        target = FileTarget(paths=("src/a.py", "src/b.py"))
+        report = _make_report()
+        record = _build_record(target, report, "", "", VALID_REVIEWED_AT)
+        assert isinstance(record, FileReviewRecord)
+        assert record.review_mode == "file"
+        assert record.file_paths == frozenset({"src/a.py", "src/b.py"})
+        assert record.reviewed_at == VALID_REVIEWED_AT
+
+    def test_file_target_working_directory_is_absolute(self) -> None:
+        """FileReviewRecord の working_directory は絶対パス。"""
+        target = FileTarget(paths=("src/a.py",))
+        report = _make_report()
+        record = _build_record(target, report, "", "", VALID_REVIEWED_AT)
+        assert isinstance(record, FileReviewRecord)
+        assert record.working_directory.startswith("/")
+
+
+# =============================================================================
+# get_commit_hash
+# =============================================================================
+
+
+class TestGetCommitHash:
+    """get_commit_hash の git コマンド実行テスト。"""
+
+    @patch("hachimoku.cli._history_writer.subprocess.run")
+    def test_returns_40char_hex_hash(self, mock_run: MagicMock) -> None:
+        """正常時に40文字のコミットハッシュを返す。"""
+        mock_run.return_value.stdout = VALID_COMMIT_HASH + "\n"
+        result = get_commit_hash()
+        assert result == VALID_COMMIT_HASH
+
+    @patch(
+        "hachimoku.cli._history_writer.subprocess.run", side_effect=FileNotFoundError
+    )
+    def test_git_not_found_raises_git_info_error(self, _mock: object) -> None:
+        """git 未インストール時に GitInfoError。"""
+        with pytest.raises(GitInfoError, match="git command not found"):
+            get_commit_hash()
+
+    @patch(
+        "hachimoku.cli._history_writer.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5),
+    )
+    def test_git_timeout_raises_git_info_error(self, _mock: object) -> None:
+        """git タイムアウト時に GitInfoError。"""
+        with pytest.raises(GitInfoError, match="timed out"):
+            get_commit_hash()
+
+    @patch(
+        "hachimoku.cli._history_writer.subprocess.run",
+        side_effect=subprocess.CalledProcessError(
+            returncode=128, cmd="git", stderr="fatal: not a git repository"
+        ),
+    )
+    def test_git_failure_raises_git_info_error(self, _mock: object) -> None:
+        """git コマンド失敗時に GitInfoError。"""
+        with pytest.raises(GitInfoError, match="git rev-parse failed"):
+            get_commit_hash()
+
+
+# =============================================================================
+# get_branch_name
+# =============================================================================
+
+
+class TestGetBranchName:
+    """get_branch_name の git コマンド実行テスト。"""
+
+    @patch("hachimoku.cli._history_writer.subprocess.run")
+    def test_returns_branch_name(self, mock_run: MagicMock) -> None:
+        """正常時にブランチ名を返す。"""
+        mock_run.return_value.stdout = "feature/auth\n"
+        result = get_branch_name()
+        assert result == "feature/auth"
+
+    @patch("hachimoku.cli._history_writer.subprocess.run")
+    def test_detached_head_returns_HEAD(self, mock_run: MagicMock) -> None:
+        """detached HEAD 時に 'HEAD' を返す。"""
+        mock_run.return_value.stdout = "HEAD\n"
+        result = get_branch_name()
+        assert result == "HEAD"
+
+    @patch(
+        "hachimoku.cli._history_writer.subprocess.run", side_effect=FileNotFoundError
+    )
+    def test_git_not_found_raises_git_info_error(self, _mock: object) -> None:
+        """git 未インストール時に GitInfoError。"""
+        with pytest.raises(GitInfoError, match="git command not found"):
+            get_branch_name()
+
+    @patch(
+        "hachimoku.cli._history_writer.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5),
+    )
+    def test_git_timeout_raises_git_info_error(self, _mock: object) -> None:
+        """git タイムアウト時に GitInfoError。"""
+        with pytest.raises(GitInfoError, match="timed out"):
+            get_branch_name()
+
+    @patch(
+        "hachimoku.cli._history_writer.subprocess.run",
+        side_effect=subprocess.CalledProcessError(
+            returncode=128, cmd="git", stderr="fatal: not a git repository"
+        ),
+    )
+    def test_git_failure_raises_git_info_error(self, _mock: object) -> None:
+        """git コマンド失敗時に GitInfoError。"""
+        with pytest.raises(GitInfoError, match="git rev-parse failed"):
+            get_branch_name()
+
+
+# =============================================================================
+# save_review_history
+# =============================================================================
+
+
+def _mock_git_subprocess(mock_run: MagicMock) -> None:
+    """subprocess.run モックに git コマンドの応答を設定する。"""
+
+    def _side_effect(
+        cmd: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=VALID_COMMIT_HASH + "\n", stderr=""
+            )
+        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=VALID_BRANCH_NAME + "\n", stderr=""
+            )
+        raise ValueError(f"Unexpected git command: {cmd}")
+
+    mock_run.side_effect = _side_effect
+
+
+class TestSaveReviewHistory:
+    """save_review_history の統合テスト。"""
+
+    @patch("hachimoku.cli._history_writer.subprocess.run")
+    def test_diff_appends_to_diff_jsonl(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """diff モードで diff.jsonl に追記される。"""
+        _mock_git_subprocess(mock_run)
+        target = DiffTarget(base_branch="main")
+        report = _make_report()
+
+        result = save_review_history(tmp_path, target, report)
+
+        assert result == tmp_path / "diff.jsonl"
+        assert result.exists()
+        lines = result.read_text().strip().splitlines()
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["review_mode"] == "diff"
+        assert data["commit_hash"] == VALID_COMMIT_HASH
+        assert data["branch_name"] == VALID_BRANCH_NAME
+
+    @patch("hachimoku.cli._history_writer.subprocess.run")
+    def test_pr_appends_to_pr_number_jsonl(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """PR モードで pr-{number}.jsonl に追記される。"""
+        _mock_git_subprocess(mock_run)
+        target = PRTarget(pr_number=42)
+        report = _make_report()
+
+        result = save_review_history(tmp_path, target, report)
+
+        assert result == tmp_path / "pr-42.jsonl"
+        data = json.loads(result.read_text().strip())
+        assert data["review_mode"] == "pr"
+        assert data["pr_number"] == 42
+
+    @patch("hachimoku.cli._history_writer.subprocess.run")
+    def test_file_appends_to_files_jsonl(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """file モードで files.jsonl に追記される。"""
+        target = FileTarget(paths=("src/a.py",))
+        report = _make_report()
+
+        result = save_review_history(tmp_path, target, report)
+
+        assert result == tmp_path / "files.jsonl"
+        data = json.loads(result.read_text().strip())
+        assert data["review_mode"] == "file"
+        # file モードでは git コマンドが呼ばれないことを検証
+        mock_run.assert_not_called()
+
+    @patch("hachimoku.cli._history_writer.subprocess.run")
+    def test_appends_to_existing_file(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """2回呼び出しで2行追記される。"""
+        _mock_git_subprocess(mock_run)
+        target = DiffTarget(base_branch="main")
+        report = _make_report()
+
+        save_review_history(tmp_path, target, report)
+        save_review_history(tmp_path, target, report)
+
+        lines = (tmp_path / "diff.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            data = json.loads(line)
+            assert data["review_mode"] == "diff"
+
+    def test_reviews_dir_not_exist_raises_history_write_error(
+        self, tmp_path: Path
+    ) -> None:
+        """reviews/ ディレクトリ不在で HistoryWriteError。"""
+        target = FileTarget(paths=("src/a.py",))
+        report = _make_report()
+        nonexistent = tmp_path / "nonexistent"
+
+        with pytest.raises(HistoryWriteError, match="does not exist"):
+            save_review_history(nonexistent, target, report)
+
+    @patch("hachimoku.cli._history_writer.subprocess.run")
+    def test_jsonl_is_valid_json_per_line(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """JSONL の各行が独立した有効な JSON オブジェクト。"""
+        _mock_git_subprocess(mock_run)
+        target = DiffTarget(base_branch="main")
+        report = _make_report()
+
+        save_review_history(tmp_path, target, report)
+
+        content = (tmp_path / "diff.jsonl").read_text()
+        # 末尾に改行がある
+        assert content.endswith("\n")
+        for line in content.strip().splitlines():
+            parsed = json.loads(line)
+            assert isinstance(parsed, dict)
+            assert "review_mode" in parsed
+            assert "reviewed_at" in parsed
+
+    def test_io_error_raises_history_write_error(self, tmp_path: Path) -> None:
+        """ファイル書き込み時の OSError が HistoryWriteError に変換される。"""
+        target = FileTarget(paths=("src/a.py",))
+        report = _make_report()
+
+        # 書き込み先を読み取り専用ディレクトリにして OSError を誘発
+        readonly_dir = tmp_path / "readonly"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(0o444)
+
+        with pytest.raises(HistoryWriteError, match="Failed to write review history"):
+            save_review_history(readonly_dir, target, report)
+
+        # クリーンアップ
+        readonly_dir.chmod(0o755)


### PR DESCRIPTION
## Summary

- FR-025/FR-026 の実装: レビュー完了後に `ReviewHistoryRecord` を JSONL 形式で `.hachimoku/reviews/` に自動蓄積
- `_history_writer.py` 新規作成: `save_review_history` / `get_commit_hash` / `get_branch_name` / `_resolve_jsonl_path` / `_build_record`
- `_app.py` に `_save_review_result` ヘルパー追加（保存失敗はレビュー exit code に影響しない設計）
- `conftest.py` に `autouse` フィクスチャ追加: テストが実ファイルシステムにレビュー履歴を書き込むことを防止
- `docs/configuration.md` に蓄積先ファイル名規則・無効化方法を追記

## Test plan

- [x] `test_history_writer.py`: 23 テスト（純粋関数・git モック・統合テスト）
- [x] `test_app.py`: `TestSaveReviewResult` 6 テスト（save_reviews フラグ・例外ハンドリング）
- [x] 全 1281 テスト通過
- [x] ruff / mypy クリーン
- [x] テスト実行後に `.hachimoku/reviews/diff.jsonl` への書き込みがないことを確認

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)