### PR TITLE
feat(#118): SelectorAgent の TOML 定義ファイル化

### DIFF
--- a/src/hachimoku/agents/__init__.py
+++ b/src/hachimoku/agents/__init__.py
@@ -1,11 +1,19 @@
 """エージェント定義・ローダー。
 
 公開 API:
-    - モデル: Phase, PHASE_ORDER, ApplicabilityRule, AgentDefinition, LoadError, LoadResult
-    - ローダー: load_builtin_agents, load_custom_agents, load_agents
+    - モデル: Phase, PHASE_ORDER, ApplicabilityRule, AgentDefinition,
+              SelectorDefinition, LoadError, LoadResult
+    - ローダー: load_builtin_agents, load_custom_agents, load_agents,
+                load_builtin_selector, load_selector
 """
 
-from hachimoku.agents.loader import load_agents, load_builtin_agents, load_custom_agents
+from hachimoku.agents.loader import (
+    load_agents,
+    load_builtin_agents,
+    load_builtin_selector,
+    load_custom_agents,
+    load_selector,
+)
 from hachimoku.agents.models import (
     PHASE_ORDER,
     AgentDefinition,
@@ -13,6 +21,7 @@ from hachimoku.agents.models import (
     LoadError,
     LoadResult,
     Phase,
+    SelectorDefinition,
 )
 
 __all__ = [
@@ -22,9 +31,12 @@ __all__ = [
     "LoadError",
     "LoadResult",
     "Phase",
+    "SelectorDefinition",
     "load_agents",
     "load_builtin_agents",
+    "load_builtin_selector",
     "load_custom_agents",
+    "load_selector",
 ]
 
 # ReviewReport.load_errors の遅延型参照を解決。

--- a/src/hachimoku/agents/_builtin/selector.toml
+++ b/src/hachimoku/agents/_builtin/selector.toml
@@ -1,0 +1,7 @@
+name = "selector"
+description = "レビュー対象を分析し、最適なレビューエージェントを選択する"
+model = "claudecode:claude-sonnet-4-5"
+allowed_tools = ["git_read", "gh_read", "file_read"]
+system_prompt = """
+You are an agent selector for code review. Analyze the review target provided in the user message, then select the most applicable review agents from the available list. Consider each agent's description, applicability rules (file_patterns, content_patterns), and phase when making your selection. Return the selected agent names and your reasoning.
+"""

--- a/src/hachimoku/agents/loader.py
+++ b/src/hachimoku/agents/loader.py
@@ -1,6 +1,7 @@
 """エージェント定義ローダー。
 
 TOML 形式のエージェント定義ファイルを読み込み、AgentDefinition モデルとして構築する。
+セレクター定義（selector.toml）は専用のローダーで読み込む。
 """
 
 from __future__ import annotations
@@ -8,10 +9,19 @@ from __future__ import annotations
 import tomllib
 from importlib.resources import as_file, files
 from pathlib import Path
+from typing import Final
 
 from pydantic import ValidationError
 
-from hachimoku.agents.models import AgentDefinition, LoadError, LoadResult
+from hachimoku.agents.models import (
+    AgentDefinition,
+    LoadError,
+    LoadResult,
+    SelectorDefinition,
+)
+
+SELECTOR_FILENAME: Final[str] = "selector.toml"
+"""セレクター定義ファイル名。レビューエージェントローダーから除外される。"""
 
 
 def _load_single_agent(path: Path) -> AgentDefinition:
@@ -33,8 +43,29 @@ def _load_single_agent(path: Path) -> AgentDefinition:
     return AgentDefinition.model_validate(data)
 
 
+def _load_single_selector(path: Path) -> SelectorDefinition:
+    """単一の TOML ファイルからセレクター定義を読み込む。
+
+    Args:
+        path: TOML ファイルのパス。
+
+    Returns:
+        構築された SelectorDefinition。
+
+    Raises:
+        tomllib.TOMLDecodeError: TOML 構文エラーの場合。
+        pydantic.ValidationError: バリデーションエラーの場合。
+        OSError: ファイルが存在しない場合やアクセスエラーの場合。
+    """
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    return SelectorDefinition.model_validate(data)
+
+
 def load_builtin_agents() -> LoadResult:
     """ビルトインエージェント定義をパッケージリソースから読み込む。
+
+    selector.toml はセレクター専用ローダーで読み込むため除外される。
 
     Returns:
         ビルトイン定義の読み込み結果。個々のファイルの読み込みエラーは
@@ -49,6 +80,8 @@ def load_builtin_agents() -> LoadResult:
 
     for resource in sorted(builtin_package.iterdir(), key=lambda r: r.name):
         if not resource.name.endswith(".toml"):
+            continue
+        if resource.name == SELECTOR_FILENAME:
             continue
         try:
             with as_file(resource) as path:
@@ -67,6 +100,8 @@ def load_builtin_agents() -> LoadResult:
 
 def load_custom_agents(custom_dir: Path) -> LoadResult:
     """カスタムエージェント定義を指定ディレクトリから読み込む。
+
+    selector.toml はセレクター専用ローダーで読み込むため除外される。
 
     Args:
         custom_dir: カスタム定義ファイルのディレクトリパス。
@@ -91,6 +126,8 @@ def load_custom_agents(custom_dir: Path) -> LoadResult:
 
     for toml_path in sorted(custom_dir.iterdir()):
         if not toml_path.name.endswith(".toml"):
+            continue
+        if toml_path.name == SELECTOR_FILENAME:
             continue
         try:
             agent = _load_single_agent(toml_path)
@@ -133,3 +170,53 @@ def load_agents(custom_dir: Path | None = None) -> LoadResult:
     merged_errors = list(builtin.errors) + list(custom.errors)
 
     return LoadResult(agents=tuple(merged_agents), errors=tuple(merged_errors))
+
+
+def load_builtin_selector() -> SelectorDefinition:
+    """ビルトインセレクター定義をパッケージリソースから読み込む。
+
+    Returns:
+        ビルトインのセレクター定義。
+
+    Raises:
+        FileNotFoundError: ビルトインセレクター定義が見つからない場合。
+        tomllib.TOMLDecodeError: TOML 構文エラーの場合。
+        pydantic.ValidationError: バリデーションエラーの場合。
+    """
+    builtin_package = files("hachimoku.agents._builtin")
+    for resource in builtin_package.iterdir():
+        if resource.name == SELECTOR_FILENAME:
+            with as_file(resource) as path:
+                return _load_single_selector(path)
+    raise FileNotFoundError(
+        f"Builtin selector definition not found: {SELECTOR_FILENAME}"
+    )
+
+
+def load_selector(custom_dir: Path | None = None) -> SelectorDefinition:
+    """ビルトインとカスタムを統合してセレクター定義を読み込む。
+
+    カスタムディレクトリに selector.toml が存在する場合、ビルトインを上書きする。
+    カスタムの読み込みに失敗した場合は例外を送出する。
+
+    Args:
+        custom_dir: カスタム定義ファイルのディレクトリパス。
+            None の場合はビルトインのみ読み込む。
+
+    Returns:
+        セレクター定義。
+
+    Raises:
+        FileNotFoundError: ビルトインセレクター定義が見つからない場合。
+        tomllib.TOMLDecodeError: TOML 構文エラーの場合。
+        pydantic.ValidationError: バリデーションエラーの場合。
+    """
+    builtin = load_builtin_selector()
+    if custom_dir is None:
+        return builtin
+
+    custom_path = custom_dir / SELECTOR_FILENAME
+    if not custom_path.exists():
+        return builtin
+
+    return _load_single_selector(custom_path)

--- a/src/hachimoku/agents/models.py
+++ b/src/hachimoku/agents/models.py
@@ -159,6 +159,25 @@ class AgentDefinition(HachimokuBaseModel):
 
 
 # =============================================================================
+# SelectorDefinition（セレクター定義）
+# =============================================================================
+
+
+class SelectorDefinition(HachimokuBaseModel):
+    """セレクターエージェントの定義。selector.toml から構築される。
+
+    AgentDefinition とは独立したモデル。セレクターは常に SelectorOutput を返し、
+    常に実行されるため、output_schema / resolved_schema / applicability / phase は不要。
+    """
+
+    name: str = Field(min_length=1, pattern=AGENT_NAME_PATTERN)
+    description: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    system_prompt: str = Field(min_length=1)
+    allowed_tools: tuple[str, ...] = ()
+
+
+# =============================================================================
 # LoadResult（読み込み結果）
 # =============================================================================
 

--- a/src/hachimoku/cli/_init_handler.py
+++ b/src/hachimoku/cli/_init_handler.py
@@ -76,7 +76,6 @@ _CONFIG_TEMPLATE: str = """\
 # model = "claudecode:claude-sonnet-4-5"
 # timeout = 600
 # max_turns = 20
-# allowed_tools = ["git_read", "gh_read", "file_read"]
 
 # --- Agent-Specific Settings ---
 # Override settings for individual agents.

--- a/src/hachimoku/engine/_engine.py
+++ b/src/hachimoku/engine/_engine.py
@@ -16,6 +16,7 @@ from typing import Final
 from hachimoku.models.exit_code import ExitCode
 
 from hachimoku.agents import load_agents
+from hachimoku.agents.loader import load_selector
 from hachimoku.agents.models import AgentDefinition, LoadError, LoadResult
 from hachimoku.config import resolve_config
 from hachimoku.engine._catalog import resolve_tools
@@ -150,8 +151,9 @@ async def run_review(
     # Step 1: 設定解決
     config = resolve_config(cli_overrides=config_overrides)
 
-    # Step 2: エージェント読み込み
+    # Step 2: エージェント読み込み + セレクター定義読み込み
     load_result = load_agents(custom_dir=custom_agents_dir)
+    selector_def = load_selector(custom_dir=custom_agents_dir)
     if load_result.errors:
         report_load_warnings(load_result.errors)
 
@@ -176,6 +178,7 @@ async def run_review(
         selector_output = await run_selector(
             target=target,
             available_agents=filtered_result.agents,
+            selector_definition=selector_def,
             selector_config=config.selector,
             global_model=config.model,
             global_timeout=config.timeout,

--- a/src/hachimoku/models/config.py
+++ b/src/hachimoku/models/config.py
@@ -16,7 +16,6 @@ from pydantic import Field, StrictBool, field_validator
 
 from hachimoku.agents.models import AGENT_NAME_PATTERN
 from hachimoku.models._base import HachimokuBaseModel
-from hachimoku.models.tool_category import ToolCategory
 
 # 既存の AGENT_NAME_PATTERN (str) をコンパイル済み正規表現として使用
 _AGENT_NAME_RE: re.Pattern[str] = re.compile(AGENT_NAME_PATTERN)
@@ -38,20 +37,12 @@ class SelectorConfig(HachimokuBaseModel):
 
     model, timeout, max_turns はオプショナル（None 可）で、
     None の場合はグローバル設定値が適用される。
-    allowed_tools はセレクターに許可されるツールカテゴリのリスト。
+    allowed_tools は selector.toml に移動済み。
     """
 
     model: str | None = Field(default=None, min_length=1)
     timeout: int | None = Field(default=None, gt=0)
     max_turns: int | None = Field(default=None, gt=0)
-    allowed_tools: list[ToolCategory] = Field(
-        default_factory=lambda: [
-            ToolCategory.GIT_READ,
-            ToolCategory.GH_READ,
-            ToolCategory.FILE_READ,
-        ],
-        min_length=1,
-    )
 
 
 class AgentConfig(HachimokuBaseModel):

--- a/tests/unit/cli/test_init_handler.py
+++ b/tests/unit/cli/test_init_handler.py
@@ -28,6 +28,7 @@ BUILTIN_AGENT_NAMES: tuple[str, ...] = (
     "code-simplifier.toml",
     "comment-analyzer.toml",
     "pr-test-analyzer.toml",
+    "selector.toml",
     "silent-failure-hunter.toml",
     "type-design-analyzer.toml",
 )
@@ -348,8 +349,8 @@ class TestRunInit:
         (agents_dir / "code-reviewer.toml").write_text("custom")
 
         result = run_init(tmp_path)
-        # config.toml + 5 agents = 6 created
-        assert len(result.created) == 6
+        # config.toml + 6 agents (selector.toml 含む) = 7 created
+        assert len(result.created) == 7
         # code-reviewer.toml は skipped
         assert len(result.skipped) == 1
 

--- a/tests/unit/engine/test_engine.py
+++ b/tests/unit/engine/test_engine.py
@@ -275,12 +275,14 @@ class TestRunReviewPipeline:
     @patch("hachimoku.engine._engine.execute_parallel")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_full_pipeline_success(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_execute: AsyncMock,
@@ -303,12 +305,14 @@ class TestRunReviewPipeline:
 
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_selector_failure_exit_code_3(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
     ) -> None:
@@ -325,12 +329,14 @@ class TestRunReviewPipeline:
 
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_empty_selection_exit_code_0(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
     ) -> None:
@@ -350,12 +356,14 @@ class TestRunReviewPipeline:
 
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_load_errors_in_report(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
     ) -> None:
@@ -380,12 +388,14 @@ class TestRunReviewPipeline:
     @patch("hachimoku.engine._engine.execute_parallel")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_all_agents_failed_exit_code_3(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_execute: AsyncMock,
@@ -407,12 +417,14 @@ class TestRunReviewPipeline:
     @patch("hachimoku.engine._engine.execute_parallel")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_severity_determines_exit_code(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_execute: AsyncMock,
@@ -437,12 +449,14 @@ class TestRunReviewPipeline:
     @patch("hachimoku.engine._engine.execute_parallel")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_disabled_agents_excluded(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_execute: AsyncMock,
@@ -477,12 +491,14 @@ class TestRunReviewPipeline:
     @patch("hachimoku.engine._engine.execute_parallel")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_multiple_agents_all_fail_mixed_errors_exit_code_3(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_execute: AsyncMock,
@@ -518,12 +534,14 @@ class TestRunReviewPipeline:
     @patch("hachimoku.engine._engine.execute_parallel")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_partial_failure_with_truncated_not_exit_code_3(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_execute: AsyncMock,
@@ -634,12 +652,14 @@ class TestRunReviewParallelSwitch:
     @patch("hachimoku.engine._engine.execute_sequential")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_parallel_true_calls_execute_parallel(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_seq: AsyncMock,
@@ -665,12 +685,14 @@ class TestRunReviewParallelSwitch:
     @patch("hachimoku.engine._engine.execute_sequential")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_parallel_false_calls_execute_sequential(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_seq: AsyncMock,
@@ -715,12 +737,14 @@ class TestRunReviewSignalIntegration:
     @patch("hachimoku.engine._engine.execute_parallel")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_signal_handlers_installed_and_uninstalled(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_execute: AsyncMock,
@@ -760,12 +784,14 @@ class TestRunReviewSignalIntegration:
     @patch("hachimoku.engine._engine.execute_parallel")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_same_shutdown_event_passed_to_install_and_executor(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_execute: AsyncMock,
@@ -800,12 +826,14 @@ class TestRunReviewSignalIntegration:
     @patch("hachimoku.engine._engine.execute_parallel")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_signal_handlers_uninstalled_on_executor_error(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_execute: AsyncMock,
@@ -832,12 +860,14 @@ class TestRunReviewSignalIntegration:
     @patch("hachimoku.engine._engine.install_signal_handlers")
     @patch("hachimoku.engine._engine.run_selector")
     @patch("hachimoku.engine._engine.resolve_content", new_callable=AsyncMock)
+    @patch("hachimoku.engine._engine.load_selector")
     @patch("hachimoku.engine._engine.load_agents")
     @patch("hachimoku.engine._engine.resolve_config")
     async def test_signal_handlers_not_installed_when_no_agents_selected(
         self,
         mock_config: MagicMock,
         mock_load: MagicMock,
+        _mock_load_selector: MagicMock,
         mock_resolve_content: AsyncMock,
         mock_selector: AsyncMock,
         mock_install: MagicMock,

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -15,7 +15,6 @@ from hachimoku.models.config import (
     OutputFormat,
     SelectorConfig,
 )
-from hachimoku.models.tool_category import ToolCategory
 
 
 # =============================================================================
@@ -315,12 +314,6 @@ class TestHachimokuConfigFrozen:
 # T006: SelectorConfig (US5, FR-CF-010)
 # =============================================================================
 
-_DEFAULT_ALLOWED_TOOLS = [
-    ToolCategory.GIT_READ,
-    ToolCategory.GH_READ,
-    ToolCategory.FILE_READ,
-]
-
 
 class TestSelectorConfigDefaults:
     """SelectorConfig のデフォルト値テスト。"""
@@ -336,10 +329,6 @@ class TestSelectorConfigDefaults:
     def test_default_max_turns(self) -> None:
         """max_turns のデフォルトが None であること。"""
         assert SelectorConfig().max_turns is None
-
-    def test_default_allowed_tools(self) -> None:
-        """allowed_tools のデフォルトが [git_read, gh_read, file_read] であること。"""
-        assert SelectorConfig().allowed_tools == _DEFAULT_ALLOWED_TOOLS
 
 
 class TestSelectorConfigValidation:
@@ -382,21 +371,6 @@ class TestSelectorConfigValidation:
         """max_turns に正の値を渡すと設定されること。"""
         assert SelectorConfig(max_turns=5).max_turns == 5
 
-    def test_allowed_tools_empty_rejected(self) -> None:
-        """allowed_tools に空リストを渡すと ValidationError が発生すること。"""
-        with pytest.raises(ValidationError, match="allowed_tools"):
-            SelectorConfig(allowed_tools=[])
-
-    def test_allowed_tools_invalid_category_rejected(self) -> None:
-        """allowed_tools に無効なカテゴリを渡すと ValidationError が発生すること。"""
-        with pytest.raises(ValidationError, match="allowed_tools"):
-            SelectorConfig(allowed_tools=["file_write"])  # type: ignore[list-item]
-
-    def test_allowed_tools_custom_subset_accepted(self) -> None:
-        """allowed_tools にカスタムサブセットを渡すと設定されること。"""
-        config = SelectorConfig(allowed_tools=["git_read", "file_read"])  # type: ignore[list-item]
-        assert config.allowed_tools == [ToolCategory.GIT_READ, ToolCategory.FILE_READ]
-
     def test_extra_field_rejected(self) -> None:
         """未知のキーを渡すと ValidationError が発生すること。"""
         with pytest.raises(ValidationError, match="extra_forbidden"):
@@ -425,4 +399,3 @@ class TestHachimokuConfigSelector:
         """辞書から selector を構築できること。"""
         config = HachimokuConfig(selector={"model": "haiku"})  # type: ignore[arg-type]
         assert config.selector.model == "haiku"
-        assert config.selector.allowed_tools == _DEFAULT_ALLOWED_TOOLS


### PR DESCRIPTION
## Summary

- SelectorAgent のハードコードされた `system_prompt` と `config.toml` の `allowed_tools` をビルトイン TOML 定義ファイル（`selector.toml`）に外部化
- `SelectorDefinition` モデルを新設し、レビューエージェントと同じ「ビルトイン + カスタムオーバーライド」パターンに統一
- `run_selector()` を3層モデル解決（`config > definition > global`）に変更

## Changes

### New
- `src/hachimoku/agents/_builtin/selector.toml` — ビルトインセレクター定義

### Modified (Production)
- `src/hachimoku/agents/models.py` — `SelectorDefinition` モデル追加
- `src/hachimoku/agents/loader.py` — `load_builtin_selector()` / `load_selector()` 追加、セレクター除外フィルタ
- `src/hachimoku/agents/__init__.py` — エクスポート追加
- `src/hachimoku/engine/_selector.py` — ハードコード削除、`SelectorDefinition` 経由に変更
- `src/hachimoku/engine/_engine.py` — `load_selector()` 呼び出し追加
- `src/hachimoku/models/config.py` — `SelectorConfig` から `allowed_tools` 削除
- `src/hachimoku/cli/_init_handler.py` — テンプレートから `allowed_tools` 行削除

### Modified (Tests)
- `tests/unit/agents/test_models.py` — `SelectorDefinition` テスト追加
- `tests/unit/agents/test_loader.py` — セレクターローダーテスト追加
- `tests/unit/engine/test_selector.py` — `SelectorDefinition` 対応に更新
- `tests/unit/engine/test_engine.py` — `load_selector` モック追加
- `tests/unit/models/test_config.py` — `allowed_tools` テスト削除
- `tests/unit/config/test_resolver.py` — `allowed_tools` テスト削除
- `tests/unit/cli/test_init_handler.py` — `selector.toml` 追加対応

## Breaking Changes

`config.toml` の `[selector].allowed_tools` は `extra="forbid"` によりバリデーションエラーとなります。v0.x のため許容。ユーザーは `config.toml` から `allowed_tools` を削除し、`.hachimoku/agents/selector.toml` でカスタマイズしてください。

## Test plan

- [x] 全1282テスト合格
- [x] `ruff check` / `ruff format` / `mypy` 全パス
- [ ] `selector.toml` のカスタムオーバーライドが正しく動作すること

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)