### PR TITLE
chore(#135): Issue テンプレートと start-issue の Review Context 対応

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -27,6 +27,18 @@ gh issue view <number> --json number,title,body,labels,state
 
 Verify the issue exists and is open. If not open, warn the user.
 
+#### Review Context の抽出
+
+Issue body から `## Review Context` セクションを抽出し、以下のフィールドを識別する:
+
+| フィールド | 用途 |
+|-----------|------|
+| 関連仕様 | Phase 1 で仕様ファイルを読み込む入力 |
+| 影響範囲 | Phase 2 の影響範囲分析の起点 |
+| 既存パターン参照 | 全フェーズで一貫性確保の指針 |
+
+フィールドが未記入の場合は、各 Phase で自動検出する。
+
 ### Step 2: Determine Branch Type
 
 Based on the issue labels and content, determine the appropriate branch prefix:
@@ -75,11 +87,15 @@ Check `documentation.ddd.enabled` to determine if DDD workflow is active.
 1. Extract requirements from issue body
 2. Identify acceptance criteria
 3. Clarify any ambiguous requirements with user
+4. `関連仕様` に記載された specs/ ファイル・憲法 Article を読み込み、要件の背景を理解する
+5. `既存パターン参照` に記載された既存実装を読み込み、一貫性の基準を把握する
 
 #### Phase 2: Identify Impact Scope
 
 1. Identify affected code files
-2. Identify affected documentation using **doc-updater skill** detection patterns:
+2. `影響範囲` に記載されたファイル・設定を影響分析の起点として使用する
+3. 自動検出の結果と統合し、issue に記載がない影響も補完する
+4. Identify affected documentation using **doc-updater skill** detection patterns:
 
 | Change Type | Documentation Impact |
 |-------------|---------------------|
@@ -169,6 +185,11 @@ Post the plan as a comment on the issue using issue-reporter skill:
 1. [Step 1]
 2. [Step 2]
 ...
+
+### Review Context
+- **関連仕様**: [参照した仕様の一覧]
+- **影響範囲**: [issue 記載 + 自動検出の統合結果]
+- **既存パターン**: [一貫性を保つべき実装の参照]
 
 ### Verification
 [Verification steps]

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: バグの報告
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Bug Report
+
+  - type: textarea
+    id: description
+    attributes:
+      label: バグの概要
+      description: 何が起きているか
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: 再現手順
+      description: バグを再現するための手順
+      placeholder: |
+        1. `8moku ...` を実行
+        2. ...
+        3. エラーが発生
+
+  - type: textarea
+    id: expected-vs-actual
+    attributes:
+      label: 期待される動作 / 実際の動作
+      description: 何が期待され、実際に何が起きたか
+      placeholder: |
+        **期待**: ...
+        **実際**: ...
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Review Context
+        以下の情報はコードレビュー時にレビューエージェントが参照します。
+        分かる範囲で記入してください。
+
+  - type: textarea
+    id: related-specs
+    attributes:
+      label: 関連仕様
+      description: 関連する仕様書・ドキュメントへの参照
+      placeholder: |
+        - specs/NNN-xxx/spec.md
+        - 憲法 Art.N（項目名）
+        - docs/xxx.md
+
+  - type: textarea
+    id: impact-scope
+    attributes:
+      label: 影響範囲
+      description: 修正が影響する可能性のあるファイル・設定（diff 外を含む）
+      placeholder: |
+        - .hachimoku/config.toml（設定の互換性）
+        - src/hachimoku/xxx.py（同じパターンを使用している箇所）
+
+  - type: textarea
+    id: existing-patterns
+    attributes:
+      label: 既存パターン参照
+      description: 修正時に一貫性を保つべき既存の類似実装
+      placeholder: |
+        - src/hachimoku/xxx.py の YYY が同様のエラーハンドリングパターン

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,60 @@
+name: Feature Request
+description: 新機能の追加・既存機能の拡張
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Feature Request
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 概要
+      description: 何を実現したいか、なぜ必要か
+      placeholder: ユーザーとして〜したい。なぜなら〜
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: 受け入れ基準
+      description: この機能が完成したと判断する条件
+      placeholder: |
+        - [ ] 基準1
+        - [ ] 基準2
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Review Context
+        以下の情報はコードレビュー時にレビューエージェントが参照します。
+        分かる範囲で記入してください。
+
+  - type: textarea
+    id: related-specs
+    attributes:
+      label: 関連仕様
+      description: 関連する仕様書・ドキュメントへの参照
+      placeholder: |
+        - specs/NNN-xxx/spec.md
+        - 憲法 Art.N（項目名）
+        - docs/xxx.md
+
+  - type: textarea
+    id: impact-scope
+    attributes:
+      label: 影響範囲
+      description: 直接変更するファイル以外に影響を受ける可能性のあるファイル・設定
+      placeholder: |
+        - .hachimoku/config.toml（新しい設定項目の追加）
+        - src/hachimoku/xxx.py（インターフェース変更の影響）
+
+  - type: textarea
+    id: existing-patterns
+    attributes:
+      label: 既存パターン参照
+      description: 一貫性を保つべき既存の類似実装
+      placeholder: |
+        - src/hachimoku/xxx.py の YYY クラスと同様のパターンで実装する


### PR DESCRIPTION
## Summary

- Issue #135 の分析に基づき、レビュー品質改善のための Issue テンプレートを新規作成
- `/start-issue` コマンドがテンプレートの Review Context セクションを活用するよう更新
- Feature Request / Bug Report テンプレートに「関連仕様」「影響範囲」「既存パターン参照」フィールドを追加

## Test plan

- [ ] GitHub の Issue 作成画面でテンプレートが表示されることを確認
- [ ] Feature Request テンプレートのフォームフィールドが正しく表示されることを確認
- [ ] Bug Report テンプレートのフォームフィールドが正しく表示されることを確認
- [ ] blank issue も引き続き作成可能であることを確認
- [ ] `/start-issue` で Review Context 付き issue を読み込んだ際、コンテキストが計画に反映されることを確認

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)