### PR TITLE
feat(#155): デフォルトモデルを claude-opus-4-6 に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ hachimoku はモデル名のプレフィックスでプロバイダーを決定�
 
 | プレフィックス | 説明 | API キー | 例 |
 |--------------|------|---------|-----|
-| `claudecode:` | Claude Code 内蔵モデル（デフォルト） | 不要 | `claudecode:claude-sonnet-4-5` |
-| `anthropic:` | Anthropic API 直接呼び出し | `ANTHROPIC_API_KEY` 必須 | `anthropic:claude-sonnet-4-5` |
+| `claudecode:` | Claude Code 内蔵モデル（デフォルト） | 不要 | `claudecode:claude-opus-4-6` |
+| `anthropic:` | Anthropic API 直接呼び出し | `ANTHROPIC_API_KEY` 必須 | `anthropic:claude-opus-4-6` |
 
 ```bash
 # Anthropic API を使用する場合
 export ANTHROPIC_API_KEY="your-api-key"
-8moku --model "anthropic:claude-sonnet-4-5"
+8moku --model "anthropic:claude-opus-4-6"
 ```
 
 ## 設定

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -49,7 +49,7 @@ hachimoku のレビューエージェントは TOML ファイルで定義され�
 
 1. `[selector]` 設定の `model`（[設定](configuration.md) 参照）
 2. セレクター定義の `model`
-3. グローバル設定の `model`（デフォルト: `"anthropic:claude-sonnet-4-5"`）
+3. グローバル設定の `model`（デフォルト: `"anthropic:claude-opus-4-6"`）
 
 ### ビルトインセレクター定義
 
@@ -117,7 +117,7 @@ print(definition.name)  # "selector"
 ```{code-block} toml
 name = "code-reviewer"
 description = "コード品質・バグ・ベストプラクティスの総合レビュー"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "scored_issues"
 phase = "main"
 allowed_tools = ["git_read", "gh_read", "file_read"]
@@ -280,7 +280,7 @@ for error in result.errors:
 
 name = "security-checker"
 description = "セキュリティ脆弱性の検出"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "scored_issues"
 allowed_tools = ["git_read", "gh_read", "file_read"]
 system_prompt = """

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ hachimoku は TOML ベースの階層的な設定システムを提供します�
 
 ```{code-block} toml
 # 実行設定
-model = "claudecode:claude-sonnet-4-5"  # プレフィックスでプロバイダーを指定
+model = "claudecode:claude-opus-4-6"  # プレフィックスでプロバイダーを指定
 timeout = 600
 max_turns = 20
 parallel = true
@@ -55,14 +55,14 @@ max_turns = 20
 # 集約エージェント設定
 [aggregation]
 enabled = true
-# model = "claudecode:claude-sonnet-4-5"
+# model = "claudecode:claude-opus-4-6"
 # timeout = 300
 # max_turns = 10
 
 # エージェント個別設定
 [agents.code-reviewer]
 enabled = true
-model = "anthropic:claude-sonnet-4-5"  # anthropic: プレフィックスで API 直接呼び出し
+model = "anthropic:claude-opus-4-6"  # anthropic: プレフィックスで API 直接呼び出し
 timeout = 600
 max_turns = 15
 
@@ -74,7 +74,7 @@ enabled = false
 
 ```{code-block} toml
 [tool.hachimoku]
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 timeout = 300
 parallel = false
 ```
@@ -87,7 +87,7 @@ parallel = false
 
 | 項目 | 型 | デフォルト | 制約 | 説明 |
 |-----|---|----------|------|------|
-| `model` | `str` | `"claudecode:claude-sonnet-4-5"` | 空文字不可、プレフィックス必須 | 使用する LLM モデル名（`claudecode:` or `anthropic:` プレフィックスでプロバイダーを指定） |
+| `model` | `str` | `"claudecode:claude-opus-4-6"` | 空文字不可、プレフィックス必須 | 使用する LLM モデル名（`claudecode:` or `anthropic:` プレフィックスでプロバイダーを指定） |
 | `timeout` | `int` | `600` | 正の値 | エージェントのタイムアウト（秒） |
 | `max_turns` | `int` | `20` | 正の値 | エージェントの最大ターン数 |
 | `parallel` | `bool` | `true` | - | 並列実行の有効化 |
@@ -126,7 +126,7 @@ parallel = false
 ```{code-block} toml
 [aggregation]
 enabled = true
-model = "claudecode:claude-sonnet-4-5"
+model = "claudecode:claude-opus-4-6"
 timeout = 300
 max_turns = 10
 ```
@@ -205,7 +205,7 @@ config = resolve_config(
     cli_overrides={"timeout": 600, "parallel": False},
 )
 
-print(config.model)      # "claudecode:claude-sonnet-4-5"
+print(config.model)      # "claudecode:claude-opus-4-6"
 print(config.timeout)    # 600（CLI オーバーライドが適用）
 print(config.parallel)   # False（CLI オーバーライドが適用）
 ```

--- a/specs/001-architecture-spec/spec.md
+++ b/specs/001-architecture-spec/spec.md
@@ -264,7 +264,7 @@
 - **FR-030**: file モードのレビュー結果は `.hachimoku/reviews/files.jsonl` に蓄積しなければならない。各行のメタデータには以下を含む: レビュー対象となったファイルパスのリスト、レビュー実行日時（ISO 8601 形式）、レビュー実行時の作業ディレクトリ（絶対パス）、AgentResult リスト、全体サマリー
 - **FR-031**: file モードは `--issue` オプションと併用可能としなければならない。`8moku src/auth.py --issue 122` のように指定した場合、Issue 番号がエージェントのプロンプトコンテキストに含まれる（diff モード・PR モードと同様の動作）
 - **FR-032**: file モードで指定されたファイル数（glob 展開・ディレクトリ再帰探索後の最終ファイル数）が設定項目 `max_files_per_review`（デフォルト: 100）を超える場合、警告メッセージを表示し確認を求めなければならない。`--no-confirm` オプション指定時は確認をスキップする
-- **FR-033**: システムは LLM プロバイダーをモデル名のプレフィックスで決定しなければならない（Issue #125 で `provider` フィールドを廃止しプレフィックスベースに統一）。`claudecode:` プレフィックスは Claude Code 内蔵モデル（API キー不要、`claudecode-model` パッケージの `ClaudeCodeModel` を使用）、`anthropic:` プレフィックスは Anthropic API 直接呼び出し（`ANTHROPIC_API_KEY` 必須）を示す。プレフィックスなしまたは未知のプレフィックスはエラーとする。デフォルトモデルは `claudecode:claude-sonnet-4-5`。プロバイダー解決は Agent 構築直前に `resolve_model()` で行う
+- **FR-033**: システムは LLM プロバイダーをモデル名のプレフィックスで決定しなければならない（Issue #125 で `provider` フィールドを廃止しプレフィックスベースに統一）。`claudecode:` プレフィックスは Claude Code 内蔵モデル（API キー不要、`claudecode-model` パッケージの `ClaudeCodeModel` を使用）、`anthropic:` プレフィックスは Anthropic API 直接呼び出し（`ANTHROPIC_API_KEY` 必須）を示す。プレフィックスなしまたは未知のプレフィックスはエラーとする。デフォルトモデルは `claudecode:claude-opus-4-6`。プロバイダー解決は Agent 構築直前に `resolve_model()` で行う
 
 ### Key Entities
 

--- a/specs/003-agent-definition/data-model.md
+++ b/specs/003-agent-definition/data-model.md
@@ -111,7 +111,7 @@ erDiagram
 ```toml
 name = "code-reviewer"
 description = "コード品質・バグ・ベストプラクティスのレビュー"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "scored_issues"
 system_prompt = """
 You are code-reviewer, an expert code quality analyst...
@@ -198,7 +198,7 @@ always = true
 # 必須フィールド
 name = "agent-name"                    # ^[a-z0-9-]+$
 description = "エージェントの説明"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "scored_issues"        # SCHEMA_REGISTRY 登録名
 system_prompt = """
 システムプロンプトの内容

--- a/specs/003-agent-definition/quickstart.md
+++ b/specs/003-agent-definition/quickstart.md
@@ -64,7 +64,7 @@ for error in result.errors:
 # .hachimoku/agents/security-reviewer.toml
 name = "security-reviewer"
 description = "セキュリティ脆弱性の検出"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "scored_issues"
 system_prompt = """
 You are a security review specialist. Focus on:

--- a/specs/004-configuration/contracts/config_models.py
+++ b/specs/004-configuration/contracts/config_models.py
@@ -47,7 +47,7 @@ class HachimokuConfig(HachimokuBaseModel):
     """
 
     # 実行設定
-    model: str = Field(default="anthropic:claude-sonnet-4-5", min_length=1)
+    model: str = Field(default="anthropic:claude-opus-4-6", min_length=1)
     timeout: int = Field(default=300, gt=0)
     max_turns: int = Field(default=10, gt=0)
     parallel: bool = True

--- a/specs/004-configuration/data-model.md
+++ b/specs/004-configuration/data-model.md
@@ -53,7 +53,7 @@
 
 | Field | Type | Default | Constraints | CLI Option | Description |
 |-------|------|---------|-------------|------------|-------------|
-| `model` | `str` | `"anthropic:claude-sonnet-4-5"` | `min_length=1` | `--model` | 使用する LLM モデル名 |
+| `model` | `str` | `"anthropic:claude-opus-4-6"` | `min_length=1` | `--model` | 使用する LLM モデル名 |
 | `timeout` | `int` | `300` | `> 0` | `--timeout` | エージェント実行タイムアウト（秒） |
 | `max_turns` | `int` | `10` | `> 0` | `--max-turns` | エージェント最大ターン数 |
 | `parallel` | `bool` | `True` | - | `--parallel` | 並列実行モード |

--- a/specs/004-configuration/quickstart.md
+++ b/specs/004-configuration/quickstart.md
@@ -15,7 +15,7 @@ from hachimoku.config import resolve_config
 
 # 全項目がデフォルト値で構成される
 config = resolve_config()
-assert config.model == "anthropic:claude-sonnet-4-5"
+assert config.model == "anthropic:claude-opus-4-6"
 assert config.timeout == 300
 assert config.parallel is True
 ```

--- a/specs/004-configuration/spec.md
+++ b/specs/004-configuration/spec.md
@@ -47,7 +47,7 @@
 2. **Given** `.hachimoku/config.toml` に `base_branch = "develop"` が設定されている, **When** 設定を解決する, **Then** `base_branch` の値が `"develop"` に解決され、他の項目はデフォルト値が適用される
 3. **Given** `.hachimoku/config.toml` と `pyproject.toml [tool.hachimoku]` の両方に `base_branch` が設定されている, **When** 設定を解決する, **Then** `.hachimoku/config.toml` の値が優先される
 4. **Given** `~/.config/hachimoku/config.toml` にのみ設定がある状態, **When** 設定を解決する, **Then** ユーザーグローバル設定の値が適用される
-5. **Given** CLI オプションで `--model anthropic:claude-sonnet-4-5` が指定され、`.hachimoku/config.toml` に `model = "anthropic:claude-opus-4-6"` が設定されている, **When** 設定を解決する, **Then** CLI オプションの `"anthropic:claude-sonnet-4-5"` が優先される
+5. **Given** CLI オプションで `--model anthropic:claude-opus-4-6` が指定され、`.hachimoku/config.toml` に `model = "anthropic:claude-opus-4-6"` が設定されている, **When** 設定を解決する, **Then** CLI オプションの `"anthropic:claude-opus-4-6"` が優先される
 6. **Given** `pyproject.toml` に `[tool.hachimoku]` セクションが存在しない, **When** 設定を解決する, **Then** `pyproject.toml` の設定ソースはスキップされ、他のソースから解決される
 
 ---
@@ -149,7 +149,7 @@
 
   | 設定キー | CLI オプション | デフォルト | 型・制約 |
   |---------|--------------|----------|---------|
-  | `model` | `--model` | `"claudecode:claude-sonnet-4-5"` | 文字列（`claudecode:` or `anthropic:` プレフィックス必須） |
+  | `model` | `--model` | `"claudecode:claude-opus-4-6"` | 文字列（`claudecode:` or `anthropic:` プレフィックス必須） |
   | `timeout` | `--timeout` | `600` | 正の整数 |
   | `max_turns` | `--max-turns` | `20` | 正の整数 |
   | `parallel` | `--parallel` | `true` | boolean |

--- a/specs/004-configuration/tasks.md
+++ b/specs/004-configuration/tasks.md
@@ -41,7 +41,7 @@
   - extra="forbid" (未知キー拒否)
 - [ ] T005 [P] Write tests for `HachimokuConfig` model in `tests/unit/models/test_config.py`:
   - デフォルト値のみでインスタンス構築可能
-  - 各フィールドのデフォルト値（model="anthropic:claude-sonnet-4-5", timeout=300, max_turns=10, parallel=True, base_branch="main", output_format=MARKDOWN, save_reviews=True, show_cost=False, max_files_per_review=100, agents={})
+  - 各フィールドのデフォルト値（model="anthropic:claude-opus-4-6", timeout=300, max_turns=10, parallel=True, base_branch="main", output_format=MARKDOWN, save_reviews=True, show_cost=False, max_files_per_review=100, agents={})
   - バリデーション: timeout/max_turns/max_files_per_review > 0, model/base_branch min_length=1, output_format enum, parallel に非 boolean 値（例: 文字列 "abc"）で ValidationError
   - agents キーの名前パターン検証（`^[a-z0-9-]+$`、不正名でエラー）
   - extra="forbid": 未知キー拒否で `ValidationError`（`match=` で未知キー名を含むことを検証）

--- a/specs/005-review-engine/data-model.md
+++ b/specs/005-review-engine/data-model.md
@@ -223,13 +223,13 @@ ReviewEngine
 AgentDefinition.model ──┐
 AgentConfig.model ──────┤  ← 個別設定が最優先
 HachimokuConfig.model ──┤  ← グローバル設定
-(default: "claudecode:claude-sonnet-4-5") ────┘  ← HachimokuConfig のデフォルト値
+(default: "claudecode:claude-opus-4-6") ────┘  ← HachimokuConfig のデフォルト値
 
 同様に timeout, max_turns も解決:
   AgentConfig.X > HachimokuConfig.X > HachimokuConfig デフォルト値
 
 セレクターのモデル解決:
-  SelectorConfig.model > SelectorDefinition.model > HachimokuConfig.model > default("claudecode:claude-sonnet-4-5")
+  SelectorConfig.model > SelectorDefinition.model > HachimokuConfig.model > default("claudecode:claude-opus-4-6")
 
 セレクターの allowed_tools:
   SelectorDefinition.allowed_tools のみ（SelectorConfig からは削除済み）
@@ -238,7 +238,7 @@ HachimokuConfig.model ──┤  ← グローバル設定
   SelectorConfig.X > HachimokuConfig.X > HachimokuConfig デフォルト値
 
 集約エージェントのモデル解決 (Issue #152):
-  AggregationConfig.model > AggregatorDefinition.model > HachimokuConfig.model > default("claudecode:claude-sonnet-4-5")
+  AggregationConfig.model > AggregatorDefinition.model > HachimokuConfig.model > default("claudecode:claude-opus-4-6")
 
 集約の timeout, max_turns (Issue #152):
   AggregationConfig.X > HachimokuConfig.X > HachimokuConfig デフォルト値

--- a/specs/005-review-engine/research.md
+++ b/specs/005-review-engine/research.md
@@ -184,11 +184,11 @@ class ReviewReport(HachimokuBaseModel):
 
 ## R-010: モデル名の解決戦略
 
-**背景**: HachimokuConfig の `model` フィールドには "sonnet" のような短縮名が使われる。pydantic-ai は "anthropic:claude-sonnet-4-5" 形式を期待する。Clarifications に「エージェント定義の `model` フィールドの値解決は本仕様の責務」と明記されている。
+**背景**: HachimokuConfig の `model` フィールドには "sonnet" のような短縮名が使われる。pydantic-ai は "anthropic:claude-opus-4-6" 形式を期待する。Clarifications に「エージェント定義の `model` フィールドの値解決は本仕様の責務」と明記されている。
 
 **Decision**: 本仕様は「値の受け渡し」（設定優先順に基づくモデル名の決定と pydantic-ai への引き渡し）を担当する。エイリアス変換（短縮名→完全修飾名）は本仕様のスコープに含めない
 
-**Rationale**: Clarifications の「値解決」は、エージェント個別設定 > グローバル設定 > デフォルト値の優先順でモデル名を決定し、AgentExecutionContext に設定する責務を指す（FR-RE-004, FR-RE-007 に対応）。一方、文字列レベルの変換（"sonnet" → "anthropic:claude-sonnet-4-5"）はモデル名体系の設計に依存し、pydantic-ai や claudecode-model のモデル名解決機構に委ねる。pydantic-ai は `Agent(model=...)` にモデル名文字列を直接受け付け、不正な名前は実行時エラーとなる。
+**Rationale**: Clarifications の「値解決」は、エージェント個別設定 > グローバル設定 > デフォルト値の優先順でモデル名を決定し、AgentExecutionContext に設定する責務を指す（FR-RE-004, FR-RE-007 に対応）。一方、文字列レベルの変換（"sonnet" → "anthropic:claude-opus-4-6"）はモデル名体系の設計に依存し、pydantic-ai や claudecode-model のモデル名解決機構に委ねる。pydantic-ai は `Agent(model=...)` にモデル名文字列を直接受け付け、不正な名前は実行時エラーとなる。
 
 **本仕様が担当する「値解決」**:
 1. エージェント個別設定のモデル名があればそれを使用
@@ -196,7 +196,7 @@ class ReviewReport(HachimokuBaseModel):
 3. 決定されたモデル名をそのまま pydantic-ai Agent に渡す
 
 **本仕様が担当しない部分**:
-- エイリアスマッピング（"sonnet" → "anthropic:claude-sonnet-4-5"）
+- エイリアスマッピング（"sonnet" → "anthropic:claude-opus-4-6"）
 - モデル名のバリデーション（pydantic-ai 側で実行時に行われる）
 
 **Alternatives considered**:

--- a/specs/006-cli-interface/spec.md
+++ b/specs/006-cli-interface/spec.md
@@ -64,7 +64,7 @@ CLI がレビュー実行を 005-review-engine に委譲し、結果を stdout �
 3. **Given** レビュー結果に問題がない状態, **When** レビューが完了する, **Then** 終了コード 0 が返される
 4. **Given** 全エージェントが実行失敗した状態, **When** レビューが完了する, **Then** 終了コード 3 が返される
 5. **Given** `8moku > result.md` のようにリダイレクトする状態, **When** レビューが完了する, **Then** `result.md` にはレビューレポートのみが含まれ、進捗情報は含まれない
-6. **Given** CLI オプション `--model anthropic:claude-sonnet-4-5 --timeout 600` を指定する状態, **When** レビューを実行する, **Then** CLI オプションの値が設定階層の最高優先として適用される
+6. **Given** CLI オプション `--model anthropic:claude-opus-4-6 --timeout 600` を指定する状態, **When** レビューを実行する, **Then** CLI オプションの値が設定階層の最高優先として適用される
 7. **Given** `--format json` を指定する状態, **When** レビューが完了する, **Then** JSON 形式のレビューレポートが stdout に出力される
 8. **Given** diff モードで `--issue 122` を指定する状態, **When** `8moku --issue 122` を実行, **Then** diff レビューに Issue #122 のコンテキストが含まれる
 9. **Given** PR モードで `--issue 50` を指定する状態, **When** `8moku 123 --issue 50` を実行, **Then** PR #123 のレビューに Issue #50 のコンテキストが含まれる

--- a/src/hachimoku/agents/_builtin/aggregator.toml
+++ b/src/hachimoku/agents/_builtin/aggregator.toml
@@ -1,6 +1,6 @@
 name = "aggregator"
 description = "複数レビューエージェントの結果を統合し、重複排除・strengths 抽出・推奨アクション生成を行う"
-model = "claudecode:claude-sonnet-4-5"
+model = "claudecode:claude-opus-4-6"
 system_prompt = """
 You are a review result aggregator. Your role is to consolidate results from multiple independent review agents into a unified, actionable report.
 

--- a/src/hachimoku/agents/_builtin/code-reviewer.toml
+++ b/src/hachimoku/agents/_builtin/code-reviewer.toml
@@ -1,6 +1,6 @@
 name = "code-reviewer"
 description = "コード品質・バグ・ベストプラクティスの総合レビュー"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "scored_issues"
 phase = "main"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/agents/_builtin/code-simplifier.toml
+++ b/src/hachimoku/agents/_builtin/code-simplifier.toml
@@ -1,6 +1,6 @@
 name = "code-simplifier"
 description = "コードの簡潔化・改善提案"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "improvement_suggestions"
 phase = "final"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/agents/_builtin/comment-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/comment-analyzer.toml
@@ -1,6 +1,6 @@
 name = "comment-analyzer"
 description = "コードコメントの正確性・品質の分析"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "category_classification"
 phase = "final"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
@@ -1,6 +1,6 @@
 name = "pr-test-analyzer"
 description = "テストカバレッジの欠落・テスト品質の分析"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "test_gap_assessment"
 phase = "main"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/agents/_builtin/selector.toml
+++ b/src/hachimoku/agents/_builtin/selector.toml
@@ -1,6 +1,6 @@
 name = "selector"
 description = "レビュー対象を分析し、最適なレビューエージェントを選択する"
-model = "claudecode:claude-sonnet-4-5"
+model = "claudecode:claude-opus-4-6"
 allowed_tools = ["git_read", "gh_read", "file_read"]
 system_prompt = """
 You are an agent selector for code review. Your role is twofold:

--- a/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
+++ b/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
@@ -1,6 +1,6 @@
 name = "silent-failure-hunter"
 description = "サイレント障害・エラーハンドリング不備の検出"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "severity_classified"
 phase = "main"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/agents/_builtin/type-design-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/type-design-analyzer.toml
@@ -1,6 +1,6 @@
 name = "type-design-analyzer"
 description = "型アノテーション・型安全性の実用分析"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "multi_dimensional_analysis"
 phase = "main"
 allowed_tools = ["git_read", "gh_read", "file_read"]

--- a/src/hachimoku/cli/_init_handler.py
+++ b/src/hachimoku/cli/_init_handler.py
@@ -40,7 +40,7 @@ _CONFIG_TEMPLATE: str = """\
 # --- Execution Settings ---
 
 # LLM model name (prefix: "claudecode:" or "anthropic:")
-# model = "claudecode:claude-sonnet-4-5"
+# model = "claudecode:claude-opus-4-6"
 
 # Timeout in seconds
 # timeout = 600
@@ -73,7 +73,7 @@ _CONFIG_TEMPLATE: str = """\
 # --- Selector Agent Settings ---
 
 # [selector]
-# model = "claudecode:claude-sonnet-4-5"
+# model = "claudecode:claude-opus-4-6"
 # timeout = 600
 # max_turns = 20
 
@@ -83,7 +83,7 @@ _CONFIG_TEMPLATE: str = """\
 #
 # [agents.code-reviewer]
 # enabled = true
-# model = "claudecode:claude-sonnet-4-5"
+# model = "claudecode:claude-opus-4-6"
 # timeout = 600
 # max_turns = 20
 """

--- a/src/hachimoku/engine/_model_resolver.py
+++ b/src/hachimoku/engine/_model_resolver.py
@@ -21,7 +21,7 @@ def resolve_model(model: str) -> str | Model:
 
     Args:
         model: プレフィックス付きモデル名文字列
-            （例: ``"claudecode:claude-sonnet-4-5"``, ``"anthropic:claude-sonnet-4-5"``）。
+            （例: ``"claudecode:claude-opus-4-6"``, ``"anthropic:claude-opus-4-6"``）。
 
     Returns:
         claudecode の場合: ``claudecode:`` プレフィックスを除去し
@@ -37,7 +37,7 @@ def resolve_model(model: str) -> str | Model:
         if not bare_name:
             raise ValueError(
                 f"Model name cannot be empty after prefix in '{model}'. "
-                "Specify a model name, e.g. 'claudecode:claude-sonnet-4-5'."
+                "Specify a model name, e.g. 'claudecode:claude-opus-4-6'."
             )
         return ClaudeCodeModel(model_name=bare_name)
 
@@ -46,7 +46,7 @@ def resolve_model(model: str) -> str | Model:
         if not bare_name:
             raise ValueError(
                 f"Model name cannot be empty after prefix in '{model}'. "
-                "Specify a model name, e.g. 'anthropic:claude-sonnet-4-5'."
+                "Specify a model name, e.g. 'anthropic:claude-opus-4-6'."
             )
         if not os.getenv("ANTHROPIC_API_KEY"):
             raise ValueError(

--- a/src/hachimoku/models/config.py
+++ b/src/hachimoku/models/config.py
@@ -80,7 +80,7 @@ class HachimokuConfig(HachimokuBaseModel):
     """
 
     # 実行設定
-    model: str = Field(default="claudecode:claude-sonnet-4-5", min_length=1)
+    model: str = Field(default="claudecode:claude-opus-4-6", min_length=1)
     timeout: int = Field(default=DEFAULT_TIMEOUT_SECONDS, gt=0)
     max_turns: int = Field(default=DEFAULT_MAX_TURNS, gt=0)
     parallel: StrictBool = True

--- a/tests/unit/agents/test_loader.py
+++ b/tests/unit/agents/test_loader.py
@@ -47,7 +47,7 @@ from hachimoku.agents.models import (
 VALID_TOML = """\
 name = "test-agent"
 description = "A test agent"
-model = "anthropic:claude-sonnet-4-5"
+model = "anthropic:claude-opus-4-6"
 output_schema = "scored_issues"
 system_prompt = "You are a test agent."
 """
@@ -116,7 +116,7 @@ class TestLoadSingleAgentValid:
         agent = _load_single_agent(path)
         assert agent.name == "test-agent"
         assert agent.description == "A test agent"
-        assert agent.model == "anthropic:claude-sonnet-4-5"
+        assert agent.model == "anthropic:claude-opus-4-6"
         assert agent.output_schema == "scored_issues"
         assert agent.system_prompt == "You are a test agent."
 
@@ -617,7 +617,7 @@ class TestBuiltinAgentSystemPromptStructure:
 VALID_SELECTOR_TOML = """\
 name = "selector"
 description = "Agent selector for code review"
-model = "claudecode:claude-sonnet-4-5"
+model = "claudecode:claude-opus-4-6"
 allowed_tools = ["git_read", "gh_read", "file_read"]
 system_prompt = "You are an agent selector."
 """
@@ -765,7 +765,7 @@ class TestLoadAgentsExcludesSelector:
 VALID_AGGREGATOR_TOML = """\
 name = "aggregator"
 description = "Aggregate review results"
-model = "claudecode:claude-sonnet-4-5"
+model = "claudecode:claude-opus-4-6"
 system_prompt = "You are a review aggregator."
 """
 

--- a/tests/unit/agents/test_models.py
+++ b/tests/unit/agents/test_models.py
@@ -234,7 +234,7 @@ def _valid_agent_data(**overrides: object) -> dict[str, object]:
     base: dict[str, object] = {
         "name": "test-agent",
         "description": "A test agent",
-        "model": "claude-sonnet-4-5-20250929",
+        "model": "claude-opus-4-6-20250929",
         "output_schema": "scored_issues",
         "system_prompt": "You are a test agent.",
     }
@@ -255,7 +255,7 @@ class TestAgentDefinitionValid:
         agent = AgentDefinition.model_validate(_valid_agent_data())
         assert agent.name == "test-agent"
         assert agent.description == "A test agent"
-        assert agent.model == "claude-sonnet-4-5-20250929"
+        assert agent.model == "claude-opus-4-6-20250929"
         assert agent.output_schema == "scored_issues"
         assert agent.system_prompt == "You are a test agent."
 
@@ -541,7 +541,7 @@ def _valid_selector_data(**overrides: object) -> dict[str, object]:
     base: dict[str, object] = {
         "name": "selector",
         "description": "Agent selector for code review",
-        "model": "claudecode:claude-sonnet-4-5",
+        "model": "claudecode:claude-opus-4-6",
         "system_prompt": "You are an agent selector.",
     }
     base.update(overrides)
@@ -561,7 +561,7 @@ class TestSelectorDefinitionValid:
         selector = SelectorDefinition.model_validate(_valid_selector_data())
         assert selector.name == "selector"
         assert selector.description == "Agent selector for code review"
-        assert selector.model == "claudecode:claude-sonnet-4-5"
+        assert selector.model == "claudecode:claude-opus-4-6"
         assert selector.system_prompt == "You are an agent selector."
 
     def test_default_allowed_tools(self) -> None:
@@ -712,9 +712,9 @@ class TestAggregatorDefinitionValid:
     def test_model_explicit(self) -> None:
         """model を明示指定できる。"""
         aggregator = AggregatorDefinition.model_validate(
-            _valid_aggregator_data(model="claudecode:claude-sonnet-4-5")
+            _valid_aggregator_data(model="claudecode:claude-opus-4-6")
         )
-        assert aggregator.model == "claudecode:claude-sonnet-4-5"
+        assert aggregator.model == "claudecode:claude-opus-4-6"
 
     def test_isinstance_hachimoku_base_model(self) -> None:
         """HachimokuBaseModel のインスタンスである。"""

--- a/tests/unit/cli/test_init_handler.py
+++ b/tests/unit/cli/test_init_handler.py
@@ -156,7 +156,7 @@ class TestGenerateConfigTemplate:
     def test_contains_default_values(self) -> None:
         """デフォルト値が含まれている。"""
         template = _generate_config_template()
-        assert '"claudecode:claude-sonnet-4-5"' in template
+        assert '"claudecode:claude-opus-4-6"' in template
         assert "600" in template
         assert "20" in template
         assert "true" in template

--- a/tests/unit/engine/test_aggregator.py
+++ b/tests/unit/engine/test_aggregator.py
@@ -195,7 +195,7 @@ class TestAggregatedReportConstraints:
 
 
 def _make_aggregator_definition(
-    model: str | None = "anthropic:claude-sonnet-4-5",
+    model: str | None = "anthropic:claude-opus-4-6",
     system_prompt: str = "You are a review aggregator.",
 ) -> AggregatorDefinition:
     """テスト用 AggregatorDefinition を生成するヘルパー。"""

--- a/tests/unit/engine/test_context.py
+++ b/tests/unit/engine/test_context.py
@@ -636,7 +636,7 @@ class TestBuildExecutionContextPhaseVariants:
             user_message="msg",
             resolved_tools=(),
         )
-        assert ctx.model == "claudecode:claude-sonnet-4-5"
+        assert ctx.model == "claudecode:claude-opus-4-6"
         assert ctx.timeout_seconds == 600
         assert ctx.max_turns == 20
 

--- a/tests/unit/engine/test_model_resolver.py
+++ b/tests/unit/engine/test_model_resolver.py
@@ -19,19 +19,19 @@ class TestResolveModelClaudeCodePrefix:
 
     def test_returns_claude_code_model_instance(self) -> None:
         """claudecode: プレフィックスで ClaudeCodeModel が返される。"""
-        result = resolve_model("claudecode:claude-sonnet-4-5")
+        result = resolve_model("claudecode:claude-opus-4-6")
         assert isinstance(result, ClaudeCodeModel)
 
     def test_returns_model_subclass(self) -> None:
         """ClaudeCodeModel は pydantic-ai Model のサブクラス。"""
-        result = resolve_model("claudecode:claude-sonnet-4-5")
+        result = resolve_model("claudecode:claude-opus-4-6")
         assert isinstance(result, Model)
 
     def test_strips_prefix(self) -> None:
         """'claudecode:' プレフィックスが除去されて model_name に渡される。"""
-        result = resolve_model("claudecode:claude-sonnet-4-5")
+        result = resolve_model("claudecode:claude-opus-4-6")
         assert isinstance(result, ClaudeCodeModel)
-        assert result.model_name == "claude-sonnet-4-5"
+        assert result.model_name == "claude-opus-4-6"
 
     def test_prefix_stripped_once(self) -> None:
         """'claudecode:' が1回だけ除去される。"""
@@ -51,32 +51,32 @@ class TestResolveModelAnthropicPrefix:
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
     def test_returns_string_as_is(self) -> None:
         """anthropic: プレフィックスではモデル文字列がそのまま返される。"""
-        result = resolve_model("anthropic:claude-sonnet-4-5")
-        assert result == "anthropic:claude-sonnet-4-5"
+        result = resolve_model("anthropic:claude-opus-4-6")
+        assert result == "anthropic:claude-opus-4-6"
 
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
     def test_returns_str_type(self) -> None:
         """戻り値が str 型であること。"""
-        result = resolve_model("anthropic:claude-sonnet-4-5")
+        result = resolve_model("anthropic:claude-opus-4-6")
         assert isinstance(result, str)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_missing_api_key_raises_error(self) -> None:
         """ANTHROPIC_API_KEY 未設定時に ValueError が発生する。"""
         with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
-            resolve_model("anthropic:claude-sonnet-4-5")
+            resolve_model("anthropic:claude-opus-4-6")
 
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"})
     def test_api_key_present_succeeds(self) -> None:
         """ANTHROPIC_API_KEY が設定されている場合は正常に処理される。"""
-        result = resolve_model("anthropic:claude-sonnet-4-5")
-        assert result == "anthropic:claude-sonnet-4-5"
+        result = resolve_model("anthropic:claude-opus-4-6")
+        assert result == "anthropic:claude-opus-4-6"
 
     @patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""})
     def test_empty_api_key_raises_error(self) -> None:
         """ANTHROPIC_API_KEY が空文字列の場合も ValueError が発生する。"""
         with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
-            resolve_model("anthropic:claude-sonnet-4-5")
+            resolve_model("anthropic:claude-opus-4-6")
 
     def test_empty_model_name_raises_error(self) -> None:
         """'anthropic:' のみ（モデル名なし）で ValueError が発生する。"""
@@ -95,4 +95,4 @@ class TestResolveModelUnknownPrefix:
     def test_no_prefix_raises_error(self) -> None:
         """プレフィックスなしのモデル名で ValueError が発生する。"""
         with pytest.raises(ValueError, match="Unknown model prefix"):
-            resolve_model("claude-sonnet-4-5")
+            resolve_model("claude-opus-4-6")

--- a/tests/unit/engine/test_selector.py
+++ b/tests/unit/engine/test_selector.py
@@ -64,7 +64,7 @@ def _make_selector_config(
 
 
 def _make_selector_definition(
-    model: str | None = "anthropic:claude-sonnet-4-5",
+    model: str | None = "anthropic:claude-opus-4-6",
     system_prompt: str = "You are an agent selector.",
     allowed_tools: tuple[str, ...] = ("git_read", "gh_read", "file_read"),
 ) -> SelectorDefinition:
@@ -598,7 +598,7 @@ class TestRunSelectorResolveModel:
             resolved_content="test diff content",
         )
 
-        mock_resolve.assert_called_once_with("anthropic:claude-sonnet-4-5")
+        mock_resolve.assert_called_once_with("anthropic:claude-opus-4-6")
         assert mock_agent_cls.call_args.kwargs["model"] == "resolved-model"
 
     @patch("hachimoku.engine._selector.resolve_model")

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -166,7 +166,7 @@ class TestHachimokuConfigDefaults:
         assert config is not None
 
     def test_default_model(self) -> None:
-        assert HachimokuConfig().model == "claudecode:claude-sonnet-4-5"
+        assert HachimokuConfig().model == "claudecode:claude-opus-4-6"
 
     def test_default_timeout(self) -> None:
         assert HachimokuConfig().timeout == 600


### PR DESCRIPTION
## Summary

- プロジェクト全体のデフォルトモデルを `claude-sonnet-4-5` から `claude-opus-4-6` に変更
- 全34ファイル（ソースコード11、ドキュメント3、仕様書11、テスト8、設定ファイル1）を一括更新
- `.hachimoku/config.toml` は .gitignore 対象のため、コミットには含まれず（ローカルのみ更新）

## Test plan

- [x] 全1428テスト通過（`pytest`）
- [x] `claude-sonnet-4-5` の残存がゼロであることを確認（`grep -r`）
- [x] ruff check / ruff format / mypy 全クリア

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)