### PR TITLE
feat(#158): レビューエージェントのノイズ削減 — 対応不要指摘のフィルタリング

### DIFF
--- a/src/hachimoku/agents/_builtin/aggregator.toml
+++ b/src/hachimoku/agents/_builtin/aggregator.toml
@@ -43,7 +43,9 @@ Create prioritized action items based on the consolidated issues:
 Include the names of any agents that failed during execution in the agent_failures list. This helps consumers understand that the aggregation may be incomplete.
 
 ## Output Rules
-- Return ALL non-duplicate issues, not just a summary
+- Exclude any issue whose description or suggestion concludes that no change is needed, no action is required, or the code is acceptable as-is. These are noise, not actionable findings.
+- Every issue in the output must require concrete developer action.
+- Return ALL non-duplicate, actionable issues, not just a summary
 - Maintain the original severity levels unless merging duplicates
 - Do not invent issues that were not in the input
 - If no issues exist, return empty lists (this is valid)

--- a/src/hachimoku/agents/_builtin/code-reviewer.toml
+++ b/src/hachimoku/agents/_builtin/code-reviewer.toml
@@ -49,6 +49,11 @@ Set overall_score on a 0.0-10.0 scale:
 - Write a concrete suggestion for each issue explaining how to fix it.
 - Use category to classify: "bug", "security", "performance", "error-handling", "style".
 
+## Self-Filtering Rules
+- Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
+- Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
+- If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+
 ## Quality Principles
 - Only report issues you are confident about. Omit uncertain findings.
 - Be language-agnostic. Do not assume a specific programming language.

--- a/src/hachimoku/agents/_builtin/code-simplifier.toml
+++ b/src/hachimoku/agents/_builtin/code-simplifier.toml
@@ -51,6 +51,11 @@ Organize each suggestion into one of these 4 categories:
 - In description, explain the before/after difference and why the simplification is beneficial.
 - Provide location (file_path + line_number) whenever applicable.
 
+## Self-Filtering Rules
+- Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
+- Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
+- If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+
 ## Quality Principles
 - Preserve all existing functionality. Never suggest changes that alter behavior.
 - Be language-agnostic. Simplification principles apply across all languages.

--- a/src/hachimoku/agents/_builtin/comment-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/comment-analyzer.toml
@@ -52,6 +52,11 @@ Classify each issue into exactly one of these 6 categories:
 - Set the category field on each ReviewIssue to match its category key.
 - Provide location (file_path + line_number) pointing to the comment in question.
 
+## Self-Filtering Rules
+- Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
+- Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
+- If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+
 ## Quality Principles
 - Verify claims by reading the actual code. Do not guess whether a comment is accurate.
 - Be language-agnostic. Comment quality principles apply across all languages.

--- a/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
@@ -51,6 +51,11 @@ Set risk_level based on overall test adequacy:
 - Set risk_level to the overall assessment of test coverage adequacy.
 - Provide location (file_path + line_number) for test quality issues.
 
+## Self-Filtering Rules
+- Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
+- Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
+- If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+
 ## Quality Principles
 - Only flag genuine coverage gaps. Do not require tests for trivial getters or configuration.
 - Be language-agnostic. Apply testing principles universally across languages and frameworks.

--- a/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
+++ b/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
@@ -45,6 +45,11 @@ Place each issue in the appropriate list:
 - Provide location (file_path + line_number) pointing to the exact error handling block.
 - Write a concrete suggestion explaining the proper error propagation strategy.
 
+## Self-Filtering Rules
+- Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
+- Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
+- If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+
 ## Quality Principles
 - Only report genuine silent failure risks. Do not flag intentional error suppression with clear comments.
 - Be language-agnostic. Apply error handling principles universally.

--- a/src/hachimoku/agents/_builtin/type-design-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/type-design-analyzer.toml
@@ -62,6 +62,11 @@ Provide exactly 5 DimensionScore entries:
 - Use issues for specific type design problems with location and suggestion.
 - Use category to classify: "annotation", "exhaustiveness", "validator", "consistency", "complexity".
 
+## Self-Filtering Rules
+- Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
+- Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
+- If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+
 ## Quality Principles
 - Prioritize how existing types are used over proposing new types. Misuse of an existing type is a higher-priority finding than a missing abstraction.
 - Evaluate against the project's actual patterns, not theoretical ideals. A design that is consistent with the rest of the codebase is good even if a "better" design exists in theory.


### PR DESCRIPTION
## Summary

- 全6レビューエージェントの system_prompt に Self-Filtering Rules セクションを追加し、対応不要と自己判断した指摘を報告から除外するルールを明文化
- アグリゲーターの Output Rules にフィルタリングルールを追加し、2層防御でノイズを削減
- PR #157 のレビューで指摘 6 件中 3 件が「No change needed」だった問題に対応

## Test plan

- [x] 既存テスト 1428 件全パス
- [x] 品質チェック通過（ruff check, ruff format, mypy）
- [ ] E2E: `hachimoku review pr 157` でノイズ指摘が除外されることを確認

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)