### PR TITLE
refactor(#166): extract _run_git_command to deduplicate git subprocess calls

### DIFF
--- a/tests/unit/cli/test_history_writer.py
+++ b/tests/unit/cli/test_history_writer.py
@@ -169,7 +169,7 @@ class TestGetCommitHash:
     )
     def test_git_failure_raises_git_info_error(self, _mock: object) -> None:
         """git コマンド失敗時に GitInfoError。"""
-        with pytest.raises(GitInfoError, match="git rev-parse failed"):
+        with pytest.raises(GitInfoError, match="git rev-parse HEAD failed"):
             get_commit_hash()
 
 
@@ -220,7 +220,9 @@ class TestGetBranchName:
     )
     def test_git_failure_raises_git_info_error(self, _mock: object) -> None:
         """git コマンド失敗時に GitInfoError。"""
-        with pytest.raises(GitInfoError, match="git rev-parse failed"):
+        with pytest.raises(
+            GitInfoError, match="git rev-parse --abbrev-ref HEAD failed"
+        ):
             get_branch_name()
 
 


### PR DESCRIPTION
## Summary
- `get_commit_hash` と `get_branch_name` の 98% 同一サブプロセス呼び出し + エラーハンドリングパターンを共通関数 `_run_git_command` に抽出
- 両関数を `_run_git_command` の呼び出しに簡潔化（各28-30行 → 各3行）
- テストのエラーメッセージ assertions を更新（コマンド全体を含むより具体的なメッセージに対応）

## Test plan
- [x] 既存テスト 22/23 パス（1件の失敗は pre-existing: root 環境での chmod テスト）
- [x] ruff check + ruff format パス
- [x] mypy パス
- [x] 公開 API（関数シグネチャ・戻り値・例外型）は変更なし

Closes #166

https://claude.ai/code/session_014YhXZzFCmY7mxPEz9KWvct