### PR TITLE
perf(#175): 全ビルトインエージェントに Confidence フィルタリングを導入

### DIFF
--- a/src/hachimoku/agents/_builtin/code-reviewer.toml
+++ b/src/hachimoku/agents/_builtin/code-reviewer.toml
@@ -49,6 +49,20 @@ Set overall_score on a 0.0-10.0 scale:
 - Write a concrete suggestion for each issue explaining how to fix it.
 - Use category to classify: "bug", "security", "performance", "error-handling", "style".
 
+## Confidence Filtering
+Before reporting each finding, assign it an internal confidence score (0-100) representing how certain you are that it is a genuine, actionable issue.
+
+### Confidence Scale
+- 91-100: Confirmed bugs, verified security vulnerabilities, or clear rule violations found by reading the actual code.
+- 76-90: Likely bugs or important best-practice violations supported by code evidence, but with some ambiguity in context.
+- 51-75: Valid concerns that are context-dependent or low-impact; the code works but could be improved.
+- 26-50: Stylistic preferences or patterns that are acceptable in context; likely not worth changing.
+- 0-25: Speculative issues with no evidence from the code; probably false positives.
+
+### Reporting Threshold
+Only report findings with confidence >= 80. Silently discard anything below this threshold.
+The confidence score is for your internal reasoning only — do not include it in the output.
+
 ## Self-Filtering Rules
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.

--- a/src/hachimoku/agents/_builtin/code-simplifier.toml
+++ b/src/hachimoku/agents/_builtin/code-simplifier.toml
@@ -51,6 +51,20 @@ Organize each suggestion into one of these 4 categories:
 - In description, explain the before/after difference and why the simplification is beneficial.
 - Provide location (file_path + line_number) whenever applicable.
 
+## Confidence Filtering
+Before reporting each finding, assign it an internal confidence score (0-100) representing how certain you are that it is a genuine, actionable issue.
+
+### Confidence Scale
+- 91-100: Confirmed dead code (zero usage verified) or extreme complexity that demonstrably hinders maintainability.
+- 76-90: Likely simplification opportunity with clear before/after improvement, supported by reading the full context.
+- 51-75: Valid simplification that depends on coding conventions or readability preferences.
+- 26-50: Minor verbosity that is acceptable in context or where the "simpler" version trades readability for brevity.
+- 0-25: Speculative simplification where you have not verified usage, or the suggestion would alter behavior.
+
+### Reporting Threshold
+Only report findings with confidence >= 80. Silently discard anything below this threshold.
+The confidence score is for your internal reasoning only — do not include it in the output.
+
 ## Self-Filtering Rules
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.

--- a/src/hachimoku/agents/_builtin/comment-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/comment-analyzer.toml
@@ -52,6 +52,20 @@ Classify each issue into exactly one of these 6 categories:
 - Set the category field on each ReviewIssue to match its category key.
 - Provide location (file_path + line_number) pointing to the comment in question.
 
+## Confidence Filtering
+Before reporting each finding, assign it an internal confidence score (0-100) representing how certain you are that it is a genuine, actionable issue.
+
+### Confidence Scale
+- 91-100: Confirmed inaccuracy — comment directly contradicts the code behavior, verified by reading the implementation.
+- 76-90: Likely inaccuracy or outdated reference supported by code evidence, but the comment could be interpreted differently.
+- 51-75: Possible inaccuracy that depends on interpretation or context not fully visible in the diff.
+- 26-50: Minor documentation gap or redundant comment that does not cause developer confusion.
+- 0-25: Speculative inaccuracy where you have not verified the referenced code, or the comment is arguably correct.
+
+### Reporting Threshold
+Only report findings with confidence >= 80. Silently discard anything below this threshold.
+The confidence score is for your internal reasoning only — do not include it in the output.
+
 ## Self-Filtering Rules
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.

--- a/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
@@ -51,6 +51,20 @@ Set risk_level based on overall test adequacy:
 - Set risk_level to the overall assessment of test coverage adequacy.
 - Provide location (file_path + line_number) for test quality issues.
 
+## Confidence Filtering
+Before reporting each finding, assign it an internal confidence score (0-100) representing how certain you are that it is a genuine, actionable issue.
+
+### Confidence Scale
+- 91-100: Confirmed missing test — critical code path has no test and no assertion covers the changed behavior.
+- 76-90: Likely coverage gap — code path is complex enough to warrant a test and none was found, but existing tests may partially cover it.
+- 51-75: Possible gap that depends on project testing conventions or risk tolerance.
+- 26-50: Minor coverage opportunity for edge cases where existing tests provide adequate regression protection.
+- 0-25: Speculative gap for trivial code (getters, configuration) or code already covered by integration tests.
+
+### Reporting Threshold
+Only report findings with confidence >= 80. Silently discard anything below this threshold.
+The confidence score is for your internal reasoning only — do not include it in the output.
+
 ## Self-Filtering Rules
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.

--- a/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
+++ b/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
@@ -45,6 +45,20 @@ Place each issue in the appropriate list:
 - Provide location (file_path + line_number) pointing to the exact error handling block.
 - Write a concrete suggestion explaining the proper error propagation strategy.
 
+## Confidence Filtering
+Before reporting each finding, assign it an internal confidence score (0-100) representing how certain you are that it is a genuine, actionable issue.
+
+### Confidence Scale
+- 91-100: Verified silent failure — error is swallowed with no logging, re-raise, or propagation, confirmed by reading caller code.
+- 76-90: Likely error-handling gap supported by reading the propagation chain, but some callers may handle it differently.
+- 51-75: Possible error-handling concern that depends on runtime conditions or external configuration.
+- 26-50: Error handling that looks unusual but is intentional (e.g., documented suppression, retry logic upstream).
+- 0-25: Speculative gap where you have not read the caller code or the pattern is standard for the language/framework.
+
+### Reporting Threshold
+Only report findings with confidence >= 80. Silently discard anything below this threshold.
+The confidence score is for your internal reasoning only — do not include it in the output.
+
 ## Self-Filtering Rules
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.

--- a/src/hachimoku/agents/_builtin/type-design-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/type-design-analyzer.toml
@@ -62,6 +62,20 @@ Provide exactly 5 DimensionScore entries:
 - Use issues for specific type design problems with location and suggestion.
 - Use category to classify: "annotation", "exhaustiveness", "validator", "consistency", "complexity".
 
+## Confidence Filtering
+Before reporting each finding, assign it an internal confidence score (0-100) representing how certain you are that it is a genuine, actionable issue.
+
+### Confidence Scale
+- 91-100: Confirmed type safety gap — missing exhaustiveness check, validator bypass, or annotation contradicted by actual return values.
+- 76-90: Likely type issue supported by reading usage sites, but with minor ambiguity about whether the gap causes bugs.
+- 51-75: Type design concern that is valid in theory but consistent with the project's existing patterns.
+- 26-50: Theoretical improvement (e.g., more precise annotation) that does not fix a concrete problem.
+- 0-25: Speculative type concern or a suggestion that contradicts the Anti-Patterns list.
+
+### Reporting Threshold
+Only report findings with confidence >= 80. Silently discard anything below this threshold.
+The confidence score is for your internal reasoning only — do not include it in the output.
+
 ## Self-Filtering Rules
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.

--- a/tests/unit/agents/test_loader.py
+++ b/tests/unit/agents/test_loader.py
@@ -609,6 +609,21 @@ class TestBuiltinAgentSystemPromptStructure:
             f"{agent_name}: system_prompt contains backslash"
         )
 
+    @pytest.mark.parametrize(
+        "agent_name",
+        sorted(BUILTIN_AGENT_NAMES),
+    )
+    def test_system_prompt_contains_confidence_filtering_section(
+        self,
+        builtin_agents: tuple[AgentDefinition, ...],
+        agent_name: str,
+    ) -> None:
+        """system_prompt に Confidence Filtering セクションを含む。"""
+        agent = _find_agent(builtin_agents, agent_name)
+        assert "## Confidence Filtering" in agent.system_prompt, (
+            f"{agent_name}: system_prompt does not contain Confidence Filtering section"
+        )
+
 
 # =============================================================================
 # ヘルパー（セレクター用）


### PR DESCRIPTION
## Summary

- 全6ビルトインエージェントの `system_prompt` に Confidence Filtering セクション（0-100 スコア、≥80 閾値）を追加
- エージェントごとにドメイン特化した信頼度 tier 記述を設定（upstream pr-review-toolkit の手法を採用）
- 構造テスト `test_system_prompt_contains_confidence_filtering_section` を追加し、全エージェントのセクション存在を保証

## Test plan

- [x] `uv run pytest tests/unit/agents/test_loader.py::TestBuiltinAgentSystemPromptStructure` — 新規テスト含む18件パス
- [x] `uv run pytest` — 全1461テストパス
- [x] `ruff check --fix . && ruff format . && mypy .` — 品質チェックパス

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)