### PR TITLE
perf(#174): 単一エージェント成功時に集約エージェントをスキップ

### DIFF
--- a/specs/005-review-engine/spec.md
+++ b/specs/005-review-engine/spec.md
@@ -184,6 +184,7 @@
 5. **Given** 集約エージェントがタイムアウトまたはエラーで失敗した状態, **When** 集約に失敗する, **Then** `ReviewReport.aggregated = None` のまま、エラー情報が ReviewReport に記録され、Step 9 までの通常レポートが返される
 6. **Given** 設定で集約が無効化されている状態（`aggregation.enabled = false`）, **When** レビューを実行する, **Then** Step 9.5 がスキップされ `ReviewReport.aggregated = None` となる
 7. **Given** 全エージェントが失敗し有効な結果が0件の状態, **When** 結果集約を行う, **Then** 集約ステップをスキップし `ReviewReport.aggregated = None` となる
+8. **Given** 有効結果（AgentSuccess / AgentTruncated）が1件のみの状態, **When** 結果集約を行う, **Then** 重複排除不要のため集約ステップをスキップし `ReviewReport.aggregated = None` となり、スキップ理由が stderr に出力される（Issue #174）
 
 ---
 
@@ -206,6 +207,7 @@
 - SelectorDefinition の `allowed_tools` にツールカタログに存在しないカテゴリ名が指定されている場合、FR-RE-016 のガードレールにより例外が送出され、レビュー実行は中断される（終了コード 3）
 - 集約エージェントが失敗した場合（タイムアウト・実行エラー・出力スキーマ違反）、`ReviewReport.aggregated = None` のまま、エラー情報を ReviewReport に記録する。終了コードには影響しない（Issue #152）
 - 全エージェントが失敗し集約への入力（AgentSuccess / AgentTruncated）が0件の場合、集約ステップをスキップする。`ReviewReport.aggregated = None`（Issue #152）
+- 有効結果（AgentSuccess / AgentTruncated）が1件のみの場合、重複排除の必要がないため集約ステップをスキップする。`ReviewReport.aggregated = None`、スキップ理由を stderr に出力する（Issue #174）
 - 設定で集約が無効化されている場合（`aggregation.enabled = false`）、Step 9.5 をスキップし `ReviewReport.aggregated = None`（Issue #152）
 - SIGINT/SIGTERM 受信時に集約ステップが実行中の場合、集約をキャンセルし Step 9 までの結果で部分レポートを生成する（`aggregated = None`）（Issue #152）
 

--- a/src/hachimoku/engine/_engine.py
+++ b/src/hachimoku/engine/_engine.py
@@ -304,9 +304,17 @@ async def _run_aggregation_step(
     if not config.aggregation.enabled:
         return report
 
-    # 有効結果なし → スキップ
-    has_valid = any(isinstance(r, (AgentSuccess, AgentTruncated)) for r in results)
-    if not has_valid:
+    # 有効結果なし or 1件のみ → スキップ（重複排除不要）
+    valid_count = sum(
+        1 for r in results if isinstance(r, (AgentSuccess, AgentTruncated))
+    )
+    if valid_count == 0:
+        return report
+    if valid_count == 1:
+        print(
+            "Aggregation skipped: only 1 valid result (no deduplication needed)",
+            file=sys.stderr,
+        )
         return report
 
     # 集約エージェント定義読み込み


### PR DESCRIPTION
## Summary

- 有効結果（AgentSuccess / AgentTruncated）が1件のみの場合、重複排除の必要がないため集約ステップをスキップ
- 既存の `any()` チェックを `sum()` によるカウントに統合し、0件/1件のスキップを一箇所で処理
- スキップ時に stderr にスキップ理由を出力（デバッグ用）
- 仕様書（spec.md）にエッジケースと User Story を追記

## Test plan

- [x] `test_aggregation_skipped_when_single_successful_agent` — AgentSuccess 1件でスキップ
- [x] `test_aggregation_skipped_when_single_truncated_agent` — AgentTruncated 1件でスキップ
- [x] `test_aggregation_skipped_when_one_success_and_failures` — 成功1件+失敗2件でスキップ
- [x] `test_aggregation_runs_when_two_successful_agents` — 2件以上で集約実行
- [x] 既存テスト3件を2エージェント構成に修正し全通過確認
- [x] 全 1465 テスト通過、ruff / mypy クリーン

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)