### PR TITLE
perf(#172): referenced_content にサイズ上限を設定しトークン消費を抑制

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,7 @@ max_files_per_review = 100
 model = "claudecode:claude-haiku-4-5"
 timeout = 600
 max_turns = 20
+referenced_content_max_chars = 5000
 
 # 集約エージェント設定
 [aggregation]
@@ -110,6 +111,7 @@ parallel = false
 | `model` | `str \| None` | `None` | 空文字不可 | モデル名の上書き（プレフィックスでプロバイダー指定） |
 | `timeout` | `int \| None` | `None` | 正の値 | タイムアウト（秒） |
 | `max_turns` | `int \| None` | `None` | 正の値 | 最大ターン数 |
+| `referenced_content_max_chars` | `int` | `5000` | 正の値 | referenced_content の各コンテンツの最大文字数。超過時は末尾切り詰め + truncation マーカー追加 |
 
 ### AggregationConfig
 

--- a/specs/005-review-engine/spec.md
+++ b/specs/005-review-engine/spec.md
@@ -18,6 +18,12 @@
 - Q: recommended_actions のデータ構造は？ → A: `RecommendedAction(description: str, priority: Priority)` のリスト。Priority enum（high/medium/low）を使用し、優先度順でソート表示可能にする
 - Q: 集約エージェントへの入力範囲は？ → A: AgentSuccess と AgentTruncated の結果のみを渡す。AggregatedReport に `agent_failures: list[str]` を追加し、失敗エージェント名を記録する。集約結果のみを参照する消費者にもレビューの不完全性が伝わるようにする
 
+### Session 2026-02-11 (Issue #172)
+
+- `referenced_content` の各 `content` にサイズ上限を導入。`SelectorConfig.referenced_content_max_chars`（デフォルト: 5000 文字）で制御
+- 上限超過時は末尾切り詰め + 未閉鎖コードフェンスの自動閉鎖 + truncation マーカー（`... (truncated, original: N chars)`）を追加
+- `build_selector_context_section()` に `max_referenced_content_chars` パラメータを追加。truncation は動的フェンス生成の前に適用される
+
 ### Session 2026-02-10 (Issue #159)
 
 - SelectorOutput に `referenced_content: list[ReferencedContent]`（default=[]）を追加。diff 内で参照されている外部リソース（Issue body、ファイル内容、仕様書等）の取得結果を保持する
@@ -229,7 +235,7 @@
   4. **レビュー指示構築**: 事前解決されたコンテンツを含むレビュー指示情報を構築する
   5. **セレクター定義読み込み**: ビルトインの `selector.toml` から SelectorDefinition を読み込む。カスタムの `selector.toml`（`.hachimoku/agents/selector.toml`）が存在する場合はビルトインを上書きする
   6. **エージェント選択（セレクターエージェント）**: SelectorDefinition と SelectorConfig に基づいてセレクターエージェント（pydantic-ai エージェント）を構築・実行し、レビュー指示情報と利用可能なエージェント定義一覧を渡す。セレクターエージェントは SelectorDefinition.allowed_tools で許可されたツールでレビュー対象を調査し、実行すべきエージェントリストを構造化出力で返す。エージェント定義の `file_patterns` / `content_patterns` / `phase` はセレクターの判断ガイダンスとして提供される
-  6.5. **セレクターメタデータ伝播**: セレクターエージェントの分析結果（変更意図・影響ファイル・関連規約・Issue コンテキスト・参照先コンテンツ）をレビューエージェント向けのユーザーメッセージに追記する。SelectorOutput の `change_intent`・`affected_files`・`relevant_conventions`・`issue_context`・`referenced_content` フィールドをマークダウンセクション化し、レビュー指示情報に結合する。`referenced_content` は diff 内で参照されている外部リソース（Issue body、ファイル内容等）の取得結果で、参照元と参照先の横断整合性チェックを可能にする（Issue #148, #159）。メタデータが全て空の場合はユーザーメッセージを変更しない
+  6.5. **セレクターメタデータ伝播**: セレクターエージェントの分析結果（変更意図・影響ファイル・関連規約・Issue コンテキスト・参照先コンテンツ）をレビューエージェント向けのユーザーメッセージに追記する。SelectorOutput の `change_intent`・`affected_files`・`relevant_conventions`・`issue_context`・`referenced_content` フィールドをマークダウンセクション化し、レビュー指示情報に結合する。`referenced_content` は diff 内で参照されている外部リソース（Issue body、ファイル内容等）の取得結果で、参照元と参照先の横断整合性チェックを可能にする（Issue #148, #159）。各 `referenced_content` の `content` は `SelectorConfig.referenced_content_max_chars`（デフォルト: 5000 文字）で切り詰められ、超過時は未閉鎖コードフェンスの自動閉鎖 + truncation マーカーが追加される（Issue #172）。メタデータが全て空の場合はユーザーメッセージを変更しない
   7. **実行コンテキスト構築**: 選択された各エージェントに対して実行コンテキスト（モデル・ツール・プロンプト・タイムアウト・最大ターン数）を構築する
   8. **エージェント実行**: 逐次または並列でエージェントを実行する
   9. **結果集約**: 各エージェントの結果（AgentResult）を ReviewReport に集約する

--- a/src/hachimoku/engine/_engine.py
+++ b/src/hachimoku/engine/_engine.py
@@ -219,13 +219,14 @@ async def run_review(
             load_result.errors, exit_code=ExitCode.SUCCESS
         )
 
-    # Step 5.5: セレクターメタデータを user_message に追記（Issue #148, #159）
+    # Step 5.5: セレクターメタデータを user_message に追記（Issue #148, #159, #172）
     selector_context = build_selector_context_section(
         change_intent=selector_output.change_intent,
         affected_files=selector_output.affected_files,
         relevant_conventions=selector_output.relevant_conventions,
         issue_context=selector_output.issue_context,
         referenced_content=selector_output.referenced_content,
+        max_referenced_content_chars=config.selector.referenced_content_max_chars,
     )
     if selector_context:
         user_message = f"{user_message}\n\n{selector_context}"

--- a/src/hachimoku/engine/_instruction.py
+++ b/src/hachimoku/engine/_instruction.py
@@ -4,18 +4,24 @@ FR-RE-001: 入力モードに応じたプロンプトコンテキストの生成
 FR-RE-011: --issue オプションの Issue 番号注入。
 FR-RE-012: PR モードでの PR メタデータ注入指示。
 Issue #129: エンジンが事前解決したコンテンツをインストラクションに埋め込む。
+Issue #172: referenced_content のサイズ上限と truncation。
 """
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from hachimoku.agents.models import AgentDefinition
 from hachimoku.engine._target import DiffTarget, FileTarget, PRTarget
+from hachimoku.models.config import DEFAULT_REFERENCED_CONTENT_MAX_CHARS
 
 if TYPE_CHECKING:
     from hachimoku.engine._selector import ReferencedContent
+
+# Issue #172: コードフェンス検出パターン（``` or ~~~、3文字以上）
+_FENCE_PATTERN: re.Pattern[str] = re.compile(r"^(`{3,}|~{3,})", re.MULTILINE)
 
 
 def build_review_instruction(
@@ -81,6 +87,59 @@ def build_selector_instruction(
     )
 
 
+def _close_unclosed_fences(text: str) -> str:
+    """切り詰めテキスト内の未閉鎖 Markdown コードフェンスを閉じる。
+
+    Issue #172: truncation でコードブロック構文が破壊されないよう、
+    未閉鎖のフェンス（``` or ~~~）を検出して対応する閉鎖マーカーを追加する。
+
+    Args:
+        text: 切り詰め済みテキスト。
+
+    Returns:
+        未閉鎖フェンスがあれば閉鎖マーカーを追加したテキスト。
+        全フェンスが閉鎖済みの場合は元のまま。
+    """
+    open_fence: str | None = None
+    for match in _FENCE_PATTERN.finditer(text):
+        marker = match.group(1)
+        if open_fence is None:
+            # フェンス開始
+            open_fence = marker
+        elif marker[0] == open_fence[0] and len(marker) >= len(open_fence):
+            # 同種かつ同等以上の長さ → フェンス閉鎖
+            open_fence = None
+        # それ以外はフェンス内のリテラルテキスト（無視）
+    if open_fence is not None:
+        return f"{text}\n{open_fence}"
+    return text
+
+
+def _truncate_content(content: str, max_chars: int) -> str:
+    """referenced_content の個別コンテンツを切り詰める。
+
+    Issue #172: 大きなドキュメントによるトークン消費を抑制するため、
+    指定文字数を超えるコンテンツを末尾切り詰め + truncation マーカー追加。
+
+    Args:
+        content: 切り詰め対象のテキスト。
+        max_chars: 最大文字数（正の整数）。
+
+    Returns:
+        上限以下の場合は元のまま。超過時は切り詰め + フェンス閉鎖 + マーカー付き。
+
+    Raises:
+        ValueError: max_chars が 1 未満の場合。
+    """
+    if max_chars < 1:
+        msg = f"max_chars must be positive, got {max_chars}"
+        raise ValueError(msg)
+    if len(content) <= max_chars:
+        return content
+    truncated = _close_unclosed_fences(content[:max_chars])
+    return f"{truncated}\n\n... (truncated, original: {len(content)} chars)"
+
+
 def build_selector_context_section(
     *,
     change_intent: str,
@@ -88,6 +147,7 @@ def build_selector_context_section(
     relevant_conventions: Sequence[str],
     issue_context: str,
     referenced_content: Sequence[ReferencedContent] = (),
+    max_referenced_content_chars: int = DEFAULT_REFERENCED_CONTENT_MAX_CHARS,
 ) -> str:
     """セレクターの分析結果をレビューエージェント向けマークダウンセクションに変換する。
 
@@ -101,6 +161,8 @@ def build_selector_context_section(
         relevant_conventions: 当該変更に関連するプロジェクト規約。
         issue_context: Issue 関連情報の要約。
         referenced_content: diff 内で参照されている外部リソースの取得結果。
+        max_referenced_content_chars: referenced_content の各 content の最大文字数。
+            Issue #172: 大きなドキュメントによるトークン消費を抑制。
 
     Returns:
         マークダウンセクション文字列。全て空の場合は空文字列。
@@ -124,12 +186,13 @@ def build_selector_context_section(
     if referenced_content:
         ref_parts: list[str] = []
         for ref in referenced_content:
+            content = _truncate_content(ref.content, max_referenced_content_chars)
             fence = "```"
-            while fence in ref.content:
+            while fence in content:
                 fence += "`"
             ref_parts.append(
                 f"#### [{ref.reference_type}] {ref.reference_id}\n"
-                f"{fence}\n{ref.content}\n{fence}"
+                f"{fence}\n{content}\n{fence}"
             )
         subsections.append("### Referenced Content\n" + "\n\n".join(ref_parts))
 

--- a/src/hachimoku/models/config.py
+++ b/src/hachimoku/models/config.py
@@ -24,6 +24,9 @@ _AGENT_NAME_RE: re.Pattern[str] = re.compile(AGENT_NAME_PATTERN)
 DEFAULT_TIMEOUT_SECONDS: Final[int] = 600
 DEFAULT_MAX_TURNS: Final[int] = 20
 
+# referenced_content のサイズ上限（Issue #172）
+DEFAULT_REFERENCED_CONTENT_MAX_CHARS: Final[int] = 5000
+
 
 class OutputFormat(StrEnum):
     """レビュー結果の出力形式。FR-CF-002."""
@@ -43,6 +46,9 @@ class SelectorConfig(HachimokuBaseModel):
     model: str | None = Field(default=None, min_length=1)
     timeout: int | None = Field(default=None, gt=0)
     max_turns: int | None = Field(default=None, gt=0)
+    referenced_content_max_chars: int = Field(
+        default=DEFAULT_REFERENCED_CONTENT_MAX_CHARS, gt=0
+    )
 
 
 class AgentConfig(HachimokuBaseModel):

--- a/tests/unit/engine/test_instruction.py
+++ b/tests/unit/engine/test_instruction.py
@@ -6,7 +6,11 @@ Issue #129: resolved_content のインストラクション埋め込み。
 """
 
 from hachimoku.agents.models import AgentDefinition, ApplicabilityRule, Phase
+import pytest
+
 from hachimoku.engine._instruction import (
+    _close_unclosed_fences,
+    _truncate_content,
     build_review_instruction,
     build_selector_context_section,
     build_selector_instruction,
@@ -509,3 +513,202 @@ class TestBuildSelectorContextSectionReferencedContent:
         assert "### Issue Context" in result
         assert "### Referenced Content" in result
         assert "specs/005/spec.md" in result
+
+
+# ── Issue #172: コンテンツ truncation ──────────────────────────────
+
+
+class TestCloseUnclosedFences:
+    """_close_unclosed_fences() のテスト。Issue #172."""
+
+    def test_no_fences(self) -> None:
+        """フェンスを含まないテキストは変更されない。"""
+        text = "plain text\nwithout fences"
+        assert _close_unclosed_fences(text) == text
+
+    def test_paired_backtick_fence(self) -> None:
+        """開始・閉鎖ペアが揃っている場合は変更されない。"""
+        text = "```python\nprint('hi')\n```"
+        assert _close_unclosed_fences(text) == text
+
+    def test_unclosed_backtick_fence(self) -> None:
+        """未閉鎖の ``` フェンスが閉じられる。"""
+        text = "intro\n```python\ncode here"
+        result = _close_unclosed_fences(text)
+        assert result == "intro\n```python\ncode here\n```"
+
+    def test_unclosed_tilde_fence(self) -> None:
+        """未閉鎖の ~~~ フェンスが閉じられる。"""
+        text = "intro\n~~~\ncode here"
+        result = _close_unclosed_fences(text)
+        assert result == "intro\n~~~\ncode here\n~~~"
+
+    def test_extended_backtick_fence(self) -> None:
+        """4+ backtick フェンスが正しく閉じられる。"""
+        text = "````\ncode with ``` inside"
+        result = _close_unclosed_fences(text)
+        assert result == "````\ncode with ``` inside\n````"
+
+    def test_mixed_fence_types(self) -> None:
+        """``` 閉鎖済み + ~~~ 未閉鎖 のケース。"""
+        text = "```\nblock1\n```\n~~~\nblock2 truncated"
+        result = _close_unclosed_fences(text)
+        assert result.endswith("\n~~~")
+
+    def test_backtick_inside_tilde_fence_ignored(self) -> None:
+        """~~~ 内の ``` はリテラルとして無視される。"""
+        text = "~~~\n```\nstill inside tilde\n"
+        result = _close_unclosed_fences(text)
+        # ~~~ が未閉鎖 → ~~~ で閉じる（``` は無関係）
+        assert result.endswith("\n~~~")
+
+
+class TestTruncateContent:
+    """_truncate_content() のテスト。Issue #172."""
+
+    def test_short_content_unchanged(self) -> None:
+        """上限以下のコンテンツは変更されない。"""
+        content = "short text"
+        assert _truncate_content(content, 100) == content
+
+    def test_exact_limit_unchanged(self) -> None:
+        """ちょうど上限のコンテンツは変更されない。"""
+        content = "A" * 100
+        assert _truncate_content(content, 100) == content
+
+    def test_over_limit_truncated(self) -> None:
+        """上限超過時に切り詰められマーカーが付く。"""
+        content = "A" * 200
+        result = _truncate_content(content, 100)
+        assert result.startswith("A" * 100)
+        assert "... (truncated, original: 200 chars)" in result
+
+    def test_marker_format(self) -> None:
+        """マーカーの形式が正しい。"""
+        content = "X" * 150
+        result = _truncate_content(content, 50)
+        assert result.endswith("... (truncated, original: 150 chars)")
+
+    def test_unclosed_fence_closed_before_marker(self) -> None:
+        """未閉鎖フェンスが閉じられた後にマーカーが付く。"""
+        # 30文字でカット → ```python\n が残り未閉鎖
+        content = "```python\nlong code line\n" + "X" * 100
+        result = _truncate_content(content, 30)
+        marker_pos = result.index("... (truncated")
+        fence_close_pos = result.rindex("```", 0, marker_pos)
+        assert fence_close_pos > 0
+
+    def test_closed_fence_no_extra_closing(self) -> None:
+        """閉鎖済みフェンスに余分な閉鎖を追加しない。"""
+        content = "```\ncode\n```\n" + "X" * 100
+        result = _truncate_content(content, 100)
+        # ``` の出現回数: 元の開始(1) + 元の閉鎖(1) のみ（truncation前に閉じている）
+        truncated_before_marker = result.split("\n\n... (truncated")[0]
+        assert truncated_before_marker.count("```") == 2
+
+    def test_zero_max_chars_raises(self) -> None:
+        """max_chars=0 で ValueError が発生する。"""
+        with pytest.raises(ValueError, match="max_chars"):
+            _truncate_content("content", 0)
+
+    def test_negative_max_chars_raises(self) -> None:
+        """負の max_chars で ValueError が発生する。"""
+        with pytest.raises(ValueError, match="max_chars"):
+            _truncate_content("content", -1)
+
+
+class TestBuildSelectorContextSectionTruncation:
+    """build_selector_context_section の truncation 統合テスト。Issue #172."""
+
+    def test_short_content_not_truncated(self) -> None:
+        """上限以下の referenced_content は変更されない。"""
+        ref = ReferencedContent(
+            reference_type="issue",
+            reference_id="#100",
+            content="Short body",
+        )
+        result = build_selector_context_section(
+            change_intent="",
+            affected_files=[],
+            relevant_conventions=[],
+            issue_context="",
+            referenced_content=[ref],
+            max_referenced_content_chars=100,
+        )
+        assert "Short body" in result
+        assert "truncated" not in result
+
+    def test_long_content_truncated(self) -> None:
+        """上限超過の referenced_content が truncation される。"""
+        content = "B" * 200
+        ref = ReferencedContent(
+            reference_type="file",
+            reference_id="spec.md",
+            content=content,
+        )
+        result = build_selector_context_section(
+            change_intent="",
+            affected_files=[],
+            relevant_conventions=[],
+            issue_context="",
+            referenced_content=[ref],
+            max_referenced_content_chars=50,
+        )
+        assert "... (truncated, original: 200 chars)" in result
+        assert content not in result
+
+    def test_dynamic_fence_accounts_for_truncation_closing(self) -> None:
+        """Truncation で追加された ``` が動的フェンス生成で考慮される。"""
+        # 未閉鎖 ``` → truncation で ``` を追加 → 動的フェンスは ```` に昇格
+        content = "```python\n" + "X" * 100
+        ref = ReferencedContent(
+            reference_type="file",
+            reference_id="code.py",
+            content=content,
+        )
+        result = build_selector_context_section(
+            change_intent="",
+            affected_files=[],
+            relevant_conventions=[],
+            issue_context="",
+            referenced_content=[ref],
+            max_referenced_content_chars=30,
+        )
+        assert "````" in result
+
+    def test_multiple_refs_each_truncated(self) -> None:
+        """複数の referenced_content が各々独立に truncation される。"""
+        refs = [
+            ReferencedContent(
+                reference_type="issue", reference_id="#1", content="A" * 200
+            ),
+            ReferencedContent(
+                reference_type="file", reference_id="f.py", content="B" * 200
+            ),
+        ]
+        result = build_selector_context_section(
+            change_intent="",
+            affected_files=[],
+            relevant_conventions=[],
+            issue_context="",
+            referenced_content=refs,
+            max_referenced_content_chars=50,
+        )
+        assert result.count("... (truncated") == 2
+
+    def test_default_max_chars_applied(self) -> None:
+        """max_referenced_content_chars 省略時にデフォルト 5000 が適用される。"""
+        content = "Z" * 6000
+        ref = ReferencedContent(
+            reference_type="spec",
+            reference_id="spec.md",
+            content=content,
+        )
+        result = build_selector_context_section(
+            change_intent="",
+            affected_files=[],
+            relevant_conventions=[],
+            issue_context="",
+            referenced_content=[ref],
+        )
+        assert "... (truncated, original: 6000 chars)" in result

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -331,6 +331,10 @@ class TestSelectorConfigDefaults:
         """max_turns のデフォルトが None であること。"""
         assert SelectorConfig().max_turns is None
 
+    def test_default_referenced_content_max_chars(self) -> None:
+        """referenced_content_max_chars のデフォルトが 5000 であること。"""
+        assert SelectorConfig().referenced_content_max_chars == 5000
+
 
 class TestSelectorConfigValidation:
     """SelectorConfig のバリデーションテスト (FR-CF-004)。"""
@@ -371,6 +375,25 @@ class TestSelectorConfigValidation:
     def test_max_turns_positive_accepted(self) -> None:
         """max_turns に正の値を渡すと設定されること。"""
         assert SelectorConfig(max_turns=5).max_turns == 5
+
+    def test_referenced_content_max_chars_zero_rejected(self) -> None:
+        """referenced_content_max_chars に 0 を渡すと ValidationError。"""
+        with pytest.raises(ValidationError, match="referenced_content_max_chars"):
+            SelectorConfig(referenced_content_max_chars=0)
+
+    def test_referenced_content_max_chars_negative_rejected(self) -> None:
+        """referenced_content_max_chars に負の値を渡すと ValidationError。"""
+        with pytest.raises(ValidationError, match="referenced_content_max_chars"):
+            SelectorConfig(referenced_content_max_chars=-1)
+
+    def test_referenced_content_max_chars_positive_accepted(self) -> None:
+        """referenced_content_max_chars に正の値を渡すと設定されること。"""
+        assert (
+            SelectorConfig(
+                referenced_content_max_chars=8000
+            ).referenced_content_max_chars
+            == 8000
+        )
 
     def test_extra_field_rejected(self) -> None:
         """未知のキーを渡すと ValidationError が発生すること。"""


### PR DESCRIPTION
## Summary

- セレクターエージェントが取得する `referenced_content` にサイズ上限（デフォルト: 5000 文字）を導入し、大きなドキュメントによるトークン消費（2,000-10,000 トークン）を抑制
- 上限超過時は末尾切り詰め + 未閉鎖コードフェンスの自動閉鎖 + truncation マーカー追加
- `SelectorConfig.referenced_content_max_chars` で設定可能

## Test plan

- [x] `_close_unclosed_fences()` 単体テスト（7 件）: フェンスなし、ペア閉鎖済み、未閉鎖 ```/~~~、拡張フェンス、混在
- [x] `_truncate_content()` 単体テスト（8 件）: 上限以下/ちょうど/超過、マーカー形式、フェンス閉鎖、ValueError
- [x] `build_selector_context_section` 統合テスト（5 件）: 短い/長いコンテンツ、動的フェンス昇格、複数 ref、デフォルト値
- [x] `SelectorConfig` バリデーションテスト（4 件）: デフォルト値、正の値、0/負の拒否
- [x] 品質チェック: `ruff check` + `ruff format` + `mypy` 全パス

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)