### PR TITLE
fix: Standardize tool reference names in instruction text

### DIFF
--- a/src/hachimoku/agents/_builtin/selector.toml
+++ b/src/hachimoku/agents/_builtin/selector.toml
@@ -13,7 +13,7 @@ For diff and PR modes, the user message contains a diff summary (not the full di
 - A table of changed files with their status (modified/new/deleted/renamed/binary) and addition/deletion counts
 - A brief preview of the first few changed lines per file
 
-This summary provides enough context for agent selection decisions. If you need to examine specific changes in detail for your metadata analysis, use git_read tools to access the full diff.
+This summary provides enough context for agent selection decisions. If you need to examine specific changes in detail for your metadata analysis, use the run_git tool to access the full diff.
 
 ## Agent Selection
 Analyze the review target provided in the user message. Consider each agent's description, applicability rules (file_patterns, content_patterns), and phase when making your selection. Return the selected agent names and your reasoning.
@@ -35,7 +35,7 @@ Only include files you have verified exist and are actually affected. Do not spe
 List project conventions relevant to this review. Check CLAUDE.md, .hachimoku/config.toml, and project documentation for applicable rules. This helps agents avoid suggesting changes that contradict project policies.
 
 ### issue_context
-If an issue number is provided, use gh tools to fetch the issue details and summarize the relevant requirements, acceptance criteria, and discussion points that help review agents understand the broader context.
+If an issue number is provided, use the run_gh tool to fetch the issue details and summarize the relevant requirements, acceptance criteria, and discussion points that help review agents understand the broader context.
 
 ### referenced_content
 When the diff or associated context mentions external references (Issue numbers like "#152", file paths like "src/foo.py", spec paths like "specs/005/spec.md", or quoted passages attributed to a source), fetch the referenced content and include it in this field. For each reference:
@@ -43,7 +43,7 @@ When the diff or associated context mentions external references (Issue numbers 
 - Set reference_id to the identifier (e.g., "#152", "src/hachimoku/models/_base.py").
 - Set content to the relevant text from the referenced source.
 
-Use gh tools to fetch issue bodies, file_read tools to read files and specs. Only include references you successfully fetched. If a reference cannot be resolved, omit it.
+Use the run_gh tool to fetch issue bodies, the read_file tool to read files and specs. Only include references you successfully fetched. If a reference cannot be resolved, omit it.
 
 This data enables review agents to verify consistency between the diff text and its referenced sources (e.g., correct quoting, accurate paraphrasing, matching terminology).
 """

--- a/src/hachimoku/engine/_instruction.py
+++ b/src/hachimoku/engine/_instruction.py
@@ -197,7 +197,7 @@ def _format_diff_summary(entries: list[_FileDiffEntry]) -> str:
     parts.append("")
     parts.append(
         "Note: This is a summary for agent selection. "
-        "Use git_read tools to access the full diff if needed."
+        "Use the run_git tool to access the full diff if needed."
     )
 
     return "\n".join(parts)
@@ -231,7 +231,7 @@ def build_review_instruction(
     if target.issue_number is not None:
         parts.append(
             f"\nRelated Issue: #{target.issue_number}\n"
-            f"Use gh tools to fetch issue details for additional context."
+            f"Use the run_gh tool to fetch issue details for additional context."
         )
 
     return "\n".join(parts)
@@ -272,7 +272,7 @@ def build_selector_instruction(
     if target.issue_number is not None:
         parts.append(
             f"\nRelated Issue: #{target.issue_number}\n"
-            f"Use gh tools to fetch issue details for additional context."
+            f"Use the run_gh tool to fetch issue details for additional context."
         )
 
     review_section = "\n".join(parts)
@@ -416,8 +416,9 @@ def _build_mode_section(
     if isinstance(target, PRTarget):
         return (
             f"Review Pull Request #{target.pr_number}.\n"
-            f"Use `gh pr view {target.pr_number}` to get PR metadata "
-            f"(title, labels, linked issues).\n\n"
+            f"Use the run_gh tool with args "
+            f'["pr", "view", "{target.pr_number}"] '
+            f"to get PR metadata (title, labels, linked issues).\n\n"
             f"{resolved_content}"
         )
 

--- a/tests/unit/engine/test_instruction.py
+++ b/tests/unit/engine/test_instruction.py
@@ -210,7 +210,7 @@ class TestBuildReviewInstructionPR:
         """PR メタデータ取得の指示は残る。"""
         target = PRTarget(pr_number=42)
         instruction = build_review_instruction(target, _SAMPLE_DIFF)
-        assert "gh pr view" in instruction
+        assert "run_gh" in instruction
 
 
 class TestBuildReviewInstructionFile:
@@ -575,9 +575,9 @@ class TestSummarizeDiffToolGuidance:
     """_summarize_diff のツールガイダンスノートテスト。Issue #170."""
 
     def test_tool_guidance_included(self) -> None:
-        """git_read ツール使用のガイダンスノートが含まれる。"""
+        """run_git ツール使用のガイダンスノートが含まれる。"""
         result = _summarize_diff(_SINGLE_FILE_DIFF)
-        assert "git_read" in result
+        assert "run_git" in result
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Standardize tool reference names across instruction strings by replacing tool-specific prefixes with unified naming conventions:
- `git_read tools` → `the run_git tool`
- `gh tools` → `the run_gh tool`
- `file_read tools` → `the read_file tool`

This improves clarity and consistency in agent instructions.

## Files Changed

- `src/hachimoku/agents/_builtin/selector.toml`: Updated selector agent instructions
- `src/hachimoku/engine/_instruction.py`: Updated review and selector instruction builders
- `tests/unit/engine/test_instruction.py`: Updated tests to match new reference names

## Test plan

- Verify all existing tests pass with the updated reference names
- Confirm agent instructions remain functionally correct
- Check that tool references are now consistently formatted across all instruction text

🤖 Generated with [Claude Code](https://claude.com/claude-code)