### PR TITLE
fix(#189): DEFAULT_MAX_TURNS を20から30に引き上げ

### DIFF
--- a/src/hachimoku/models/config.py
+++ b/src/hachimoku/models/config.py
@@ -28,7 +28,7 @@ _AGENT_NAME_RE: re.Pattern[str] = re.compile(AGENT_NAME_PATTERN)
 
 # グローバルデフォルト値（Issue #130: 複雑なレビューに対応するため引き上げ）
 DEFAULT_TIMEOUT_SECONDS: Final[int] = 600
-DEFAULT_MAX_TURNS: Final[int] = 20
+DEFAULT_MAX_TURNS: Final[int] = 30
 
 # referenced_content のサイズ上限（Issue #172）
 DEFAULT_REFERENCED_CONTENT_MAX_CHARS: Final[int] = 5000

--- a/tests/unit/config/test_resolver.py
+++ b/tests/unit/config/test_resolver.py
@@ -334,7 +334,7 @@ class TestResolveConfigOnlyProjectConfig:
         assert config.model == "opus"
         assert config.timeout == 600
         # 他はデフォルト
-        assert config.max_turns == 20
+        assert config.max_turns == 30
 
 
 class TestResolveConfigOnlyPyprojectConfig:
@@ -350,7 +350,7 @@ class TestResolveConfigOnlyPyprojectConfig:
             config = resolve_config(start_dir=tmp_path)
         assert config.model == "haiku"
         assert config.timeout == 120
-        assert config.max_turns == 20  # デフォルト
+        assert config.max_turns == 30  # デフォルト
 
 
 class TestResolveConfigOnlyUserGlobalConfig:
@@ -361,7 +361,7 @@ class TestResolveConfigOnlyUserGlobalConfig:
         user_config_dir = tmp_path / "user_home" / ".config" / "hachimoku"
         _write_toml(
             user_config_dir / "config.toml",
-            'model = "user-model"\nmax_turns = 20\n',
+            'model = "user-model"\nmax_turns = 30\n',
         )
         with patch(
             "hachimoku.config._resolver.get_user_config_path",
@@ -369,7 +369,7 @@ class TestResolveConfigOnlyUserGlobalConfig:
         ):
             config = resolve_config(start_dir=tmp_path)
         assert config.model == "user-model"
-        assert config.max_turns == 20
+        assert config.max_turns == 30
         assert config.timeout == 600  # デフォルト
 
 

--- a/tests/unit/engine/test_context.py
+++ b/tests/unit/engine/test_context.py
@@ -638,7 +638,7 @@ class TestBuildExecutionContextPhaseVariants:
         )
         assert ctx.model == "claudecode:claude-opus-4-6"
         assert ctx.timeout_seconds == 600
-        assert ctx.max_turns == 20
+        assert ctx.max_turns == 30
 
     def test_early_phase_propagated(self) -> None:
         """Phase.EARLY が正しく設定される。"""

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -172,7 +172,7 @@ class TestHachimokuConfigDefaults:
         assert HachimokuConfig().timeout == 600
 
     def test_default_max_turns(self) -> None:
-        assert HachimokuConfig().max_turns == 20
+        assert HachimokuConfig().max_turns == 30
 
     def test_default_parallel(self) -> None:
         """parallel のデフォルトが True であること。"""


### PR DESCRIPTION
## Summary
- DEFAULT_MAX_TURNS を 20 から 30 に増加させました
- 大規模なPRのレビューでエージェントのターン数制限に達する問題を解決します
- テストのアサーション値も併せて更新しました

## Test plan
- [ ] 通常サイズのPRでレビューが正常に動作することを確認
- [ ] 大規模なPRでエージェントがターン数制限に達しないことを確認
- [ ] 既存のユニットテストがすべて通ることを確認

生成: [Claude Code](https://claude.com/claude-code)