### PR TITLE
docs(#206): デフォルト出力形式 Markdown に合わせてドキュメント更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ hachimoku（8moku）は、複数の専門エージェントを用いてコード
 - LLM ベース結果集約: 複数エージェントの指摘を重複排除・統合し、推奨アクションを生成
 - コスト効率化: セレクター・集約は軽量モデル、レビューは高性能モデルで精度を維持
 - 柔軟なモデル設定: config → definition → global の優先順位で解決、いつでも Opus 4.6 に戻せる
-- JSON 出力対応（Markdown は今後対応予定）
+- Markdown / JSON 出力対応（デフォルトは Markdown）
 
 ## インストール
 
@@ -75,7 +75,7 @@ uv sync
 | `--model TEXT` | LLM モデル名（プレフィックス付き: `claudecode:` or `anthropic:`） |
 | `--timeout INTEGER` | タイムアウト秒数 |
 | `--parallel / --no-parallel` | 並列実行の有効/無効 |
-| `--format json` | 出力形式 |
+| `--format FORMAT` | 出力形式（`markdown` / `json`、デフォルト: `markdown`） |
 | `--base-branch TEXT` | diff モードのベースブランチ |
 | `--issue INTEGER` | コンテキスト用 GitHub Issue 番号 |
 | `--no-confirm` | 確認プロンプトをスキップ |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,7 +50,7 @@ hachimoku は `8moku` と `hachimoku` の2つのコマンド名を提供しま�
 | `--max-turns INTEGER` | int (min: 1) | エージェントの最大ターン数 |
 | `--parallel / --no-parallel` | bool | 並列実行の有効/無効 |
 | `--base-branch TEXT` | str | diff モードのベースブランチ |
-| `--format json` | OutputFormat | 出力形式（現在は JSON のみ対応） |
+| `--format FORMAT` | OutputFormat | 出力形式（`markdown` / `json`、デフォルト: `markdown`） |
 | `--save-reviews / --no-save-reviews` | bool | レビュー結果の保存 |
 | `--show-cost / --no-show-cost` | bool | コスト情報の表示 |
 | `--max-files INTEGER` | int (min: 1) | レビュー対象の最大ファイル数 |
@@ -135,10 +135,10 @@ stderr
 
 ```bash
 # レポートをファイルに保存
-8moku > review.json
+8moku > review.md
 
 # レポートを別のコマンドにパイプ
-8moku | jq '.agents'
+8moku --format json | jq '.agents'
 ```
 
 ## 終了コード


### PR DESCRIPTION
## Summary

実装済みの変更（#201 で Markdown をデフォルト出力形式に変更）に合わせて、ユーザー向けドキュメントを更新しました：

- README.md の features セクションで Markdown 出力対応を明記し、デフォルトは Markdown であることを表示
- CLI オプション説明で `--format` をデフォルト値と共に正確に記述
- docs/cli.md の出力形式説明と実行例を Markdown ベースに更新

## Test plan

- README.md が正確に表示されることを確認
- docs/cli.md ページが正確に表示されることを確認
- CLI ヘルプで `--format` オプションの説明が正確に表示されることを確認

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)