### PR TITLE
docs(#207): uv tool install ガイドを README と installation.md に追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,21 @@ hachimoku（8moku）は、複数の専門エージェントを用いてコード
 
 ## インストール
 
-現在 PyPI には未公開です。ソースからインストールしてください。
+現在 PyPI には未公開です。`uv tool install` でグローバルにインストールできます。
+
+```bash
+uv tool install git+https://github.com/drillan/hachimoku.git
+```
+
+開発者向け（ソースからのセットアップ）:
 
 ```bash
 git clone https://github.com/drillan/hachimoku.git
 cd hachimoku
 uv sync
 ```
+
+詳細は [インストール](docs/installation.md) を参照してください。
 
 ## クイックスタート
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,39 @@
 - Python 3.13 以上
 - Git（diff モード・PR モードで必要）
 
-## ソースからインストール
+## グローバルインストール（uv tool install）
+
+`uv tool install` を使うと、仮想環境を明示的にアクティベートせずに `8moku` / `hachimoku` コマンドをグローバルに利用できます。
+
+### Git URL からインストール
+
+リポジトリを直接指定してインストールします:
+
+```bash
+uv tool install git+https://github.com/drillan/hachimoku.git
+```
+
+### ローカルクローンからインストール
+
+リポジトリをクローンしてからインストールします:
+
+```bash
+git clone https://github.com/drillan/hachimoku.git
+cd hachimoku
+uv tool install .
+```
+
+### uv sync との使い分け
+
+| 方法 | 対象 | 用途 |
+|------|------|------|
+| `uv tool install` | 利用者 | グローバルにコマンドをインストールしてレビューツールとして使用 |
+| `uv sync` | 開発者 | プロジェクトディレクトリ内で開発・テスト・デバッグ |
+
+- **利用者**: `uv tool install` でインストールすれば、任意のディレクトリから `8moku` コマンドを実行できます
+- **開発者**: `uv sync` でプロジェクトの仮想環境に依存関係を同期し、`uv run` 経由でコマンドを実行します
+
+## ソースからインストール（開発用）
 
 リポジトリをクローンして依存関係を同期します:
 


### PR DESCRIPTION
## 概要

- PyPI 未公開時の利用者向けインストール方法（`uv tool install`）を README に追加
- `docs/installation.md` に詳細なグローバルインストール手順を記載
- `uv tool install` と `uv sync` の使い分けを明確化

## テスト計画

- [ ] README.md のインストールセクション全体が正しく表示されることを確認
- [ ] docs/installation.md の全セクションが読みやすく整理されていることを確認
- [ ] 提供されたコマンド（`uv tool install git+https://github.com/drillan/hachimoku.git`）が実際に動作することを確認
- [ ] ローカルクローンからのインストール手順が正確であることを確認
- [ ] 表形式で `uv tool install` と `uv sync` の使い分けが明確に示されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)