### PR TITLE
fix(#220): CLI レビュー実行時に custom_agents_dir が渡されるよう修正

### DIFF
--- a/src/hachimoku/cli/_app.py
+++ b/src/hachimoku/cli/_app.py
@@ -305,10 +305,20 @@ def review_callback(
     # 4. ReviewTarget 構築
     target = _build_target(resolved, config, issue)
 
+    # 4.5. カスタムエージェントディレクトリ解決
+    project_root = find_project_root(Path.cwd())
+    custom_agents_dir = (
+        (project_root / ".hachimoku" / "agents") if project_root else None
+    )
+
     # 5. run_review() 呼び出し
     try:
         result = asyncio.run(
-            run_review(target=target, config_overrides=config_overrides)
+            run_review(
+                target=target,
+                config_overrides=config_overrides,
+                custom_agents_dir=custom_agents_dir,
+            )
         )
     except (KeyboardInterrupt, SystemExit):
         raise


### PR DESCRIPTION
## Summary
- Issue #220 で報告されたバグを修正
- CLI レビュー実行時に `custom_agents_dir` が `run_review()` に渡されていなかった
- `find_project_root()` で project_root を解決し、`.hachimoku/agents` を導出して渡すよう修正
- 3 つのテストケース（diff/file モード、project_root あり/なし）を追加

Closes #220

## Test plan
- `TestCustomAgentsDirPassedToRunReview` の 3 test case が全て通ることを確認
- 既存テスト `pytest` が全て通ることを確認
- 品質チェック `ruff check --fix . && ruff format . && mypy .` が全て通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)