### PR TITLE
docs(#226): init コマンド実行時に作成されるファイル一覧を完成させる

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,6 +97,8 @@ file モードでは以下の処理が行われます:
 
 - `.hachimoku/config.toml` - 設定ファイル（全オプションがコメントアウトされたテンプレート）
 - `.hachimoku/agents/*.toml` - ビルトインエージェント定義のコピー
+- `.hachimoku/reviews/` - レビュー結果の JSONL 蓄積ディレクトリ
+- `.gitignore` への `/.hachimoku/` エントリ自動追加（未登録の場合のみ）
 
 ## agents
 


### PR DESCRIPTION
## Summary

`.hachimoku/reviews/` ディレクトリと `.gitignore` への自動追加について、documentation を補全した。

Closes #226

## Test plan

- [ ] ドキュメントが正確に反映されていることを確認
- [ ] `hachimoku init` コマンドでの実際の動作と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)