### PR TITLE
i18n(#238): Convert builtin agent descriptions to English

### DIFF
--- a/src/hachimoku/agents/_builtin/aggregator.toml
+++ b/src/hachimoku/agents/_builtin/aggregator.toml
@@ -1,5 +1,5 @@
 name = "aggregator"
-description = "複数レビューエージェントの結果を統合し、重複排除・strengths 抽出・推奨アクション生成を行う"
+description = "Consolidates results from multiple review agents with deduplication, strengths extraction, and recommended action generation"
 model = "claudecode:claude-haiku-4-5"
 system_prompt = """
 You are a review result aggregator. Your role is to consolidate results from multiple independent review agents into a unified, actionable report.

--- a/src/hachimoku/agents/_builtin/code-reviewer.toml
+++ b/src/hachimoku/agents/_builtin/code-reviewer.toml
@@ -1,5 +1,5 @@
 name = "code-reviewer"
-description = "コード品質・バグ・ベストプラクティスの総合レビュー"
+description = "Comprehensive review of code quality, bugs, and best practices"
 model = "claudecode:claude-opus-4-6"
 output_schema = "scored_issues"
 phase = "main"

--- a/src/hachimoku/agents/_builtin/code-simplifier.toml
+++ b/src/hachimoku/agents/_builtin/code-simplifier.toml
@@ -1,5 +1,5 @@
 name = "code-simplifier"
-description = "コードの簡潔化・改善提案"
+description = "Code simplification and improvement suggestions"
 model = "claudecode:claude-opus-4-6"
 output_schema = "improvement_suggestions"
 phase = "final"

--- a/src/hachimoku/agents/_builtin/comment-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/comment-analyzer.toml
@@ -1,5 +1,5 @@
 name = "comment-analyzer"
-description = "コードコメントの正確性・品質の分析"
+description = "Analysis of code comment accuracy and quality"
 model = "claudecode:claude-opus-4-6"
 output_schema = "category_classification"
 phase = "final"

--- a/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
@@ -1,5 +1,5 @@
 name = "pr-test-analyzer"
-description = "テストカバレッジの欠落・テスト品質の分析"
+description = "Analysis of test coverage gaps and test quality"
 model = "claudecode:claude-opus-4-6"
 output_schema = "test_gap_assessment"
 phase = "main"

--- a/src/hachimoku/agents/_builtin/selector.toml
+++ b/src/hachimoku/agents/_builtin/selector.toml
@@ -1,5 +1,5 @@
 name = "selector"
-description = "レビュー対象を分析し、最適なレビューエージェントを選択する"
+description = "Analyzes review targets and selects optimal review agents"
 model = "claudecode:claude-opus-4-6"
 allowed_tools = ["git_read", "gh_read", "file_read"]
 system_prompt = """

--- a/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
+++ b/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
@@ -1,5 +1,5 @@
 name = "silent-failure-hunter"
-description = "サイレント障害・エラーハンドリング不備の検出"
+description = "Detection of silent failures and inadequate error handling"
 model = "claudecode:claude-opus-4-6"
 output_schema = "severity_classified"
 phase = "main"

--- a/src/hachimoku/agents/_builtin/type-design-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/type-design-analyzer.toml
@@ -1,5 +1,5 @@
 name = "type-design-analyzer"
-description = "型アノテーション・型安全性の実用分析"
+description = "Practical analysis of type annotations and type safety"
 model = "claudecode:claude-opus-4-6"
 output_schema = "multi_dimensional_analysis"
 phase = "main"

--- a/tests/unit/agents/test_loader.py
+++ b/tests/unit/agents/test_loader.py
@@ -551,7 +551,10 @@ class TestLoadAgents:
         _write_toml(tmp_path, "code-reviewer.toml", 'name = "unclosed')
         result = load_agents(custom_dir=tmp_path)
         agent = _find_agent(result.agents, "code-reviewer")
-        assert agent.description == "コード品質・バグ・ベストプラクティスの総合レビュー"
+        assert (
+            agent.description
+            == "Comprehensive review of code quality, bugs, and best practices"
+        )
         assert len(result.errors) == 1
 
     def test_errors_merged(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Convert all builtin agent description fields from Japanese to English for better internationalization support
- Update test expectations to match new English descriptions
- Supports the ongoing i18n effort for the project

Closes #238

## Test plan
- Run existing unit tests to verify descriptions are correctly loaded
- Manual verification that all 8 builtin agents have English descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)