### PR TITLE
docs(#242): Update Sphinx conf.py to dynamically fetch release version from pyproject.toml

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -1,7 +1,9 @@
+import importlib.metadata
+
 project = "hachimoku"
 copyright = "2026, driller"
 author = "driller"
-release = "0.0.1"
+release = importlib.metadata.version("hachimoku")
 language = "en"
 
 extensions = [

--- a/docs/ja/conf.py
+++ b/docs/ja/conf.py
@@ -1,7 +1,9 @@
+import importlib.metadata
+
 project = "hachimoku"
 copyright = "2026, driller"
 author = "driller"
-release = "0.0.1"
+release = importlib.metadata.version("hachimoku")
 language = "ja"
 
 extensions = [


### PR DESCRIPTION
## Summary
- Replace hardcoded release version with `importlib.metadata.version()` in Sphinx configuration
- Keep documentation in sync with package version defined in pyproject.toml
- Applies to both English and Japanese documentation (docs/en/conf.py and docs/ja/conf.py)

Closes #242

## Test plan
- [ ] Build documentation with `make -C docs html` and verify both EN and JA versions display correct version
- [ ] Verify version matches the version in pyproject.toml
- [ ] Check that no hardcoded version strings remain in conf.py files

🤖 Generated with [Claude Code](https://claude.com/claude-code)