### PR TITLE
fix(#246): Replace comment-based fallback with explicit assert_never exhaustiveness guard

### DIFF
--- a/src/hachimoku/cli/_app.py
+++ b/src/hachimoku/cli/_app.py
@@ -529,8 +529,9 @@ def _build_target(
         return DiffTarget(base_branch=config.base_branch, issue_number=issue)
     if isinstance(resolved, PRInput):
         return PRTarget(pr_number=resolved.pr_number, issue_number=issue)
-    # FileInput
-    return FileTarget(paths=resolved.paths, issue_number=issue)
+    if isinstance(resolved, FileInput):
+        return FileTarget(paths=resolved.paths, issue_number=issue)
+    assert_never(resolved)
 
 
 def _save_review_result(

--- a/tests/unit/cli/test_app.py
+++ b/tests/unit/cli/test_app.py
@@ -1692,3 +1692,19 @@ class TestVersion:
         expected = importlib.metadata.version("hachimoku")
         result = runner.invoke(app, ["--version"])
         assert expected in result.output
+
+
+class TestBuildTargetExhaustiveness:
+    """_build_target の assert_never 網羅性ガードを検証する（Issue #246）。"""
+
+    def test_unknown_resolved_input_raises_assertion_error(self) -> None:
+        """ResolvedInput 以外の型 → AssertionError が発生する。"""
+        from hachimoku.cli._app import _build_target
+        from hachimoku.models.schemas._base import HachimokuBaseModel
+
+        class UnknownInput(HachimokuBaseModel):
+            mode: str = "unknown"
+
+        config = HachimokuConfig()
+        with pytest.raises(AssertionError):
+            _build_target(UnknownInput(), config, issue=None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
Replace implicit comment-based handling of `FileInput` in `_build_target` with explicit `isinstance` check and `assert_never` guard. This ensures compile-time exhaustiveness checking and prevents accidental missing case handling.

Added test case `TestBuildTargetExhaustiveness` to verify the exhaustiveness guard works correctly when an unknown `ResolvedInput` subtype is encountered.

Closes #246

## Test plan
- Verified `_build_target` correctly handles all three input types:
  - `DiffInput` → `DiffTarget`
  - `PRInput` → `PRTarget`
  - `FileInput` → `FileTarget`
- New test `test_unknown_resolved_input_raises_assertion_error` confirms that passing an unknown input type raises `AssertionError`
- All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)