### PR TITLE
refactor(#248): Consolidate agent result row formatting

### DIFF
--- a/src/hachimoku/cli/_markdown_formatter.py
+++ b/src/hachimoku/cli/_markdown_formatter.py
@@ -163,14 +163,10 @@ def _format_agent_result_row(
     agent_result: AgentSuccess | AgentError | AgentTimeout | AgentTruncated,
 ) -> str:
     match agent_result:
-        case AgentSuccess():
+        case AgentSuccess() | AgentTruncated():
             issue_count = str(len(agent_result.issues))
             time_display = f"{agent_result.elapsed_time:.1f}s"
-            return f"| {agent_result.agent_name} | success | {issue_count} | {time_display} |"
-        case AgentTruncated():
-            issue_count = str(len(agent_result.issues))
-            time_display = f"{agent_result.elapsed_time:.1f}s"
-            return f"| {agent_result.agent_name} | truncated | {issue_count} | {time_display} |"
+            return f"| {agent_result.agent_name} | {agent_result.status} | {issue_count} | {time_display} |"
         case AgentError():
             return f"| {agent_result.agent_name} | error | - | - |"
         case AgentTimeout():


### PR DESCRIPTION
## Summary
Consolidate the `AgentSuccess` and `AgentTruncated` match cases in `_format_agent_result_row` by using `agent_result.status` property instead of hardcoded status strings. This reduces code duplication while maintaining the same behavior.

Closes #248

## Test plan
- Existing markdown formatting tests pass without modification
- Manual verification: Review markdown output format for agent results with both success and truncated statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)