### PR TITLE
fix(#260): Extract StrEnum case-normalization logic into reusable utility

### DIFF
--- a/src/hachimoku/models/_base.py
+++ b/src/hachimoku/models/_base.py
@@ -1,7 +1,10 @@
-"""全ドメインモデルの基底クラス。
+"""全ドメインモデルの基底クラスと共通ユーティリティ。
 
 FR-DM-009: extra="forbid" で厳格モードを一元管理。
+FR-DM-010: normalize_enum_value による StrEnum ケース正規化。
 """
+
+from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict
 
@@ -10,3 +13,24 @@ class HachimokuBaseModel(BaseModel):
     """全ドメインモデルの基底クラス。extra="forbid" で厳格モードを一元管理。"""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+def normalize_enum_value[E: StrEnum](v: object, enum_cls: type[E]) -> object:
+    """StrEnum 入力を正規化する（大文字小文字非依存）。
+
+    str 入力を enum_cls のメンバー値と case-insensitive でマッチし、
+    正規の値文字列に変換する。マッチしない str や str 以外の入力は
+    そのまま返し、後続の Pydantic バリデーションに委ねる。
+
+    Args:
+        v: バリデーション対象の入力値。
+        enum_cls: マッチ対象の StrEnum クラス。
+
+    Returns:
+        正規化された値文字列、またはマッチしない場合は入力値そのまま。
+    """
+    if isinstance(v, str):
+        for member in enum_cls:
+            if v.lower() == member.value.lower():
+                return member.value
+    return v

--- a/src/hachimoku/models/report.py
+++ b/src/hachimoku/models/report.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import Field, field_validator, model_validator
 
-from hachimoku.models._base import HachimokuBaseModel
+from hachimoku.models._base import HachimokuBaseModel, normalize_enum_value
 from hachimoku.models.agent_result import AgentResult, CostInfo
 from hachimoku.models.review import ReviewIssue
 from hachimoku.models.severity import Severity
@@ -46,16 +46,8 @@ class RecommendedAction(HachimokuBaseModel):
     @field_validator("priority", mode="before")
     @classmethod
     def normalize_priority(cls, v: object) -> object:
-        """Priority 入力を lowercase に正規化する。
-
-        LLM が "High" や "HIGH" を出力する場合に対応する。
-        """
-        if isinstance(v, str):
-            lower = v.lower()
-            for member in Priority:
-                if lower == member.value:
-                    return member.value
-        return v
+        """Priority 入力を lowercase に正規化する。"""
+        return normalize_enum_value(v, Priority)
 
 
 class AggregatedReport(HachimokuBaseModel):

--- a/src/hachimoku/models/review.py
+++ b/src/hachimoku/models/review.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pydantic import Field, field_validator
 
-from hachimoku.models._base import HachimokuBaseModel
+from hachimoku.models._base import HachimokuBaseModel, normalize_enum_value
 from hachimoku.models.severity import Severity
 
 
@@ -40,14 +40,5 @@ class ReviewIssue(HachimokuBaseModel):
     @field_validator("severity", mode="before")
     @classmethod
     def normalize_severity(cls, v: object) -> object:
-        """Severity 入力を PascalCase に正規化する。
-
-        大文字小文字非依存で Severity メンバーとマッチし、
-        PascalCase の値に変換する。マッチしない str や
-        str 以外の入力はそのまま返し、後続のバリデーションに委ねる。
-        """
-        if isinstance(v, str):
-            for member in Severity:
-                if v.lower() == member.value.lower():
-                    return member.value
-        return v
+        """Severity 入力を PascalCase に正規化する。"""
+        return normalize_enum_value(v, Severity)

--- a/src/hachimoku/models/schemas/improvement_suggestions.py
+++ b/src/hachimoku/models/schemas/improvement_suggestions.py
@@ -5,9 +5,9 @@ code-simplifier が使用する出力スキーマ。
 
 from __future__ import annotations
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
-from hachimoku.models._base import HachimokuBaseModel
+from hachimoku.models._base import HachimokuBaseModel, normalize_enum_value
 from hachimoku.models.review import FileLocation
 from hachimoku.models.schemas._base import BaseAgentOutput
 from hachimoku.models.severity import Severity
@@ -20,6 +20,12 @@ class ImprovementItem(HachimokuBaseModel):
     description: str = Field(min_length=1)
     priority: Severity
     location: FileLocation | None = None
+
+    @field_validator("priority", mode="before")
+    @classmethod
+    def normalize_priority(cls, v: object) -> object:
+        """priority 入力を PascalCase に正規化する。"""
+        return normalize_enum_value(v, Severity)
 
 
 class ImprovementSuggestions(BaseAgentOutput):

--- a/src/hachimoku/models/schemas/test_gap.py
+++ b/src/hachimoku/models/schemas/test_gap.py
@@ -5,9 +5,9 @@ pr-test-analyzer が使用する出力スキーマ。
 
 from __future__ import annotations
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
-from hachimoku.models._base import HachimokuBaseModel
+from hachimoku.models._base import HachimokuBaseModel, normalize_enum_value
 from hachimoku.models.schemas._base import BaseAgentOutput
 from hachimoku.models.severity import Severity
 
@@ -19,9 +19,21 @@ class CoverageGap(HachimokuBaseModel):
     description: str = Field(min_length=1)
     priority: Severity
 
+    @field_validator("priority", mode="before")
+    @classmethod
+    def normalize_priority(cls, v: object) -> object:
+        """priority 入力を PascalCase に正規化する。"""
+        return normalize_enum_value(v, Severity)
+
 
 class TestGapAssessment(BaseAgentOutput):
     """テストギャップ評価。"""
 
     coverage_gaps: list[CoverageGap]
     risk_level: Severity
+
+    @field_validator("risk_level", mode="before")
+    @classmethod
+    def normalize_risk_level(cls, v: object) -> object:
+        """risk_level 入力を PascalCase に正規化する。"""
+        return normalize_enum_value(v, Severity)

--- a/tests/unit/models/test_base.py
+++ b/tests/unit/models/test_base.py
@@ -1,12 +1,14 @@
-"""HachimokuBaseModel のテスト。
+"""HachimokuBaseModel と共通ユーティリティのテスト。
 
 FR-DM-009: 全モデルは extra="forbid" の厳格モードで動作する。
+FR-DM-010: normalize_enum_value による StrEnum ケース正規化。
 """
 
 import pytest
 from pydantic import ValidationError
 
-from hachimoku.models._base import HachimokuBaseModel
+from hachimoku.models._base import HachimokuBaseModel, normalize_enum_value
+from hachimoku.models.severity import Severity
 
 
 class SampleModel(HachimokuBaseModel):
@@ -50,3 +52,51 @@ class TestHachimokuBaseModelFrozen:
         model = SampleModel(name="test", value=42)
         with pytest.raises(ValidationError, match="frozen"):
             model.value = -999  # type: ignore[assignment]
+
+
+class TestNormalizeEnumValue:
+    """normalize_enum_value の動作を検証。
+
+    FR-DM-010: StrEnum のケース非依存正規化。
+    """
+
+    def test_lowercase_normalized_to_pascalcase(self) -> None:
+        """小文字入力が PascalCase に正規化される。"""
+        assert normalize_enum_value("critical", Severity) == "Critical"
+
+    def test_uppercase_normalized_to_pascalcase(self) -> None:
+        """大文字入力が PascalCase に正規化される。"""
+        assert normalize_enum_value("IMPORTANT", Severity) == "Important"
+
+    def test_mixed_case_normalized(self) -> None:
+        """混合ケースが正規化される。"""
+        assert normalize_enum_value("sUgGeStIoN", Severity) == "Suggestion"
+
+    @pytest.mark.parametrize(
+        ("input_str", "expected"),
+        [
+            ("critical", "Critical"),
+            ("important", "Important"),
+            ("suggestion", "Suggestion"),
+            ("nitpick", "Nitpick"),
+        ],
+    )
+    def test_all_severity_values(self, input_str: str, expected: str) -> None:
+        """全 Severity 値について正規化を検証。"""
+        assert normalize_enum_value(input_str, Severity) == expected
+
+    def test_already_correct_case_passthrough(self) -> None:
+        """既に正しいケースの値はそのまま返される。"""
+        assert normalize_enum_value("Critical", Severity) == "Critical"
+
+    def test_invalid_string_passthrough(self) -> None:
+        """マッチしない文字列はそのまま返される。"""
+        assert normalize_enum_value("invalid", Severity) == "invalid"
+
+    def test_non_string_passthrough(self) -> None:
+        """非 str 型はそのまま返される。"""
+        assert normalize_enum_value(42, Severity) == 42
+
+    def test_none_passthrough(self) -> None:
+        """None はそのまま返される。"""
+        assert normalize_enum_value(None, Severity) is None

--- a/tests/unit/models/test_schemas.py
+++ b/tests/unit/models/test_schemas.py
@@ -302,6 +302,66 @@ class TestCoverageGapValid:
         assert isinstance(gap, HachimokuBaseModel)
 
 
+class TestCoverageGapPriorityCaseInsensitive:
+    """CoverageGap.priority のケース非依存入力を検証。"""
+
+    def test_lowercase_priority_accepted(self) -> None:
+        """小文字入力が Severity.CRITICAL に正規化される。"""
+        gap = CoverageGap(
+            file_path="src/main.py",
+            description="desc",
+            priority="critical",  # type: ignore[arg-type]
+        )
+        assert gap.priority == Severity.CRITICAL
+
+    def test_uppercase_priority_accepted(self) -> None:
+        """大文字入力が Severity.IMPORTANT に正規化される。"""
+        gap = CoverageGap(
+            file_path="src/main.py",
+            description="desc",
+            priority="IMPORTANT",  # type: ignore[arg-type]
+        )
+        assert gap.priority == Severity.IMPORTANT
+
+    @pytest.mark.parametrize(
+        ("input_str", "expected"),
+        [
+            ("critical", Severity.CRITICAL),
+            ("important", Severity.IMPORTANT),
+            ("suggestion", Severity.SUGGESTION),
+            ("nitpick", Severity.NITPICK),
+        ],
+    )
+    def test_all_severity_values_case_insensitive(
+        self, input_str: str, expected: Severity
+    ) -> None:
+        """全4値について小文字入力を検証。"""
+        gap = CoverageGap(
+            file_path="src/main.py",
+            description="desc",
+            priority=input_str,  # type: ignore[arg-type]
+        )
+        assert gap.priority == expected
+
+    def test_invalid_priority_rejected(self) -> None:
+        """不正な文字列で ValidationError。"""
+        with pytest.raises(ValidationError):
+            CoverageGap(
+                file_path="src/main.py",
+                description="desc",
+                priority="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_enum_value_accepted(self) -> None:
+        """Severity enum インスタンスも受け入れる。"""
+        gap = CoverageGap(
+            file_path="src/main.py",
+            description="desc",
+            priority=Severity.SUGGESTION,
+        )
+        assert gap.priority == Severity.SUGGESTION
+
+
 class TestCoverageGapConstraints:
     """CoverageGap の制約を検証。"""
 
@@ -374,6 +434,57 @@ class TestTestGapAssessmentValid:
             risk_level=Severity.NITPICK,
         )
         assert isinstance(assessment, BaseAgentOutput)
+
+
+class TestTestGapAssessmentRiskLevelCaseInsensitive:
+    """TestGapAssessment.risk_level のケース非依存入力を検証。"""
+
+    def test_lowercase_risk_level_accepted(self) -> None:
+        """小文字入力が Severity.CRITICAL に正規化される。"""
+        assessment = TestGapAssessment(
+            issues=[],
+            coverage_gaps=[],
+            risk_level="critical",  # type: ignore[arg-type]
+        )
+        assert assessment.risk_level == Severity.CRITICAL
+
+    def test_uppercase_risk_level_accepted(self) -> None:
+        """大文字入力が Severity.IMPORTANT に正規化される。"""
+        assessment = TestGapAssessment(
+            issues=[],
+            coverage_gaps=[],
+            risk_level="IMPORTANT",  # type: ignore[arg-type]
+        )
+        assert assessment.risk_level == Severity.IMPORTANT
+
+    @pytest.mark.parametrize(
+        ("input_str", "expected"),
+        [
+            ("critical", Severity.CRITICAL),
+            ("important", Severity.IMPORTANT),
+            ("suggestion", Severity.SUGGESTION),
+            ("nitpick", Severity.NITPICK),
+        ],
+    )
+    def test_all_severity_values_case_insensitive(
+        self, input_str: str, expected: Severity
+    ) -> None:
+        """全4値について小文字入力を検証。"""
+        assessment = TestGapAssessment(
+            issues=[],
+            coverage_gaps=[],
+            risk_level=input_str,  # type: ignore[arg-type]
+        )
+        assert assessment.risk_level == expected
+
+    def test_invalid_risk_level_rejected(self) -> None:
+        """不正な文字列で ValidationError。"""
+        with pytest.raises(ValidationError):
+            TestGapAssessment(
+                issues=[],
+                coverage_gaps=[],
+                risk_level="invalid",  # type: ignore[arg-type]
+            )
 
 
 class TestTestGapAssessmentConstraints:
@@ -582,6 +693,57 @@ class TestImprovementItemValid:
         """HachimokuBaseModel のインスタンスである。"""
         item = ImprovementItem(title="t", description="d", priority=Severity.NITPICK)
         assert isinstance(item, HachimokuBaseModel)
+
+
+class TestImprovementItemPriorityCaseInsensitive:
+    """ImprovementItem.priority のケース非依存入力を検証。"""
+
+    def test_lowercase_priority_accepted(self) -> None:
+        """小文字入力が Severity.SUGGESTION に正規化される。"""
+        item = ImprovementItem(
+            title="t",
+            description="d",
+            priority="suggestion",  # type: ignore[arg-type]
+        )
+        assert item.priority == Severity.SUGGESTION
+
+    def test_uppercase_priority_accepted(self) -> None:
+        """大文字入力が Severity.CRITICAL に正規化される。"""
+        item = ImprovementItem(
+            title="t",
+            description="d",
+            priority="CRITICAL",  # type: ignore[arg-type]
+        )
+        assert item.priority == Severity.CRITICAL
+
+    @pytest.mark.parametrize(
+        ("input_str", "expected"),
+        [
+            ("critical", Severity.CRITICAL),
+            ("important", Severity.IMPORTANT),
+            ("suggestion", Severity.SUGGESTION),
+            ("nitpick", Severity.NITPICK),
+        ],
+    )
+    def test_all_severity_values_case_insensitive(
+        self, input_str: str, expected: Severity
+    ) -> None:
+        """全4値について小文字入力を検証。"""
+        item = ImprovementItem(
+            title="t",
+            description="d",
+            priority=input_str,  # type: ignore[arg-type]
+        )
+        assert item.priority == expected
+
+    def test_invalid_priority_rejected(self) -> None:
+        """不正な文字列で ValidationError。"""
+        with pytest.raises(ValidationError):
+            ImprovementItem(
+                title="t",
+                description="d",
+                priority="invalid",  # type: ignore[arg-type]
+            )
 
 
 class TestImprovementItemConstraints:


### PR DESCRIPTION
## Summary

Extract the StrEnum case-normalization logic into a reusable `normalize_enum_value()` utility function in `src/hachimoku/models/_base.py`. This implements FR-DM-010 requirement and eliminates duplicate validation code across multiple models.

**Key Changes:**
- Added `normalize_enum_value()` function for case-insensitive StrEnum matching
- Refactored existing validators: `RecommendedAction.normalize_priority()` and `ReviewIssue.normalize_severity()`
- Applied consistent normalization pattern to: `CoverageGap.priority`, `TestGapAssessment.risk_level`, and `ImprovementItem.priority`
- Added comprehensive unit tests covering all Severity enum values and edge cases

**DRY Improvement:** Reduced duplication from 3 validator implementations to 1 centralized utility function used consistently across 5 validators.

Closes #260

## Test plan

- [x] All existing tests pass
- [x] New test class `TestNormalizeEnumValue` validates utility function with all Severity values
- [x] New test classes for case-insensitive input: `TestCoverageGapPriorityCaseInsensitive`, `TestTestGapAssessmentRiskLevelCaseInsensitive`, `TestImprovementItemPriorityCaseInsensitive`
- [x] Edge cases covered: lowercase, uppercase, mixed case, already correct case, invalid strings, non-string types, None
- [x] Quality checks passed: `ruff check --fix`, `ruff format`, `mypy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)