### PR TITLE
fix(#282): Raise IsADirectoryError when path is a directory in read_file()

### DIFF
--- a/src/hachimoku/engine/_tools/_file.py
+++ b/src/hachimoku/engine/_tools/_file.py
@@ -18,10 +18,15 @@ def read_file(path: str) -> str:
         ファイルの内容（UTF-8）。
 
     Raises:
+        IsADirectoryError: パスがディレクトリの場合。
         FileNotFoundError: ファイルが存在しない場合。
         ValueError: ファイルが有効な UTF-8 テキストでない場合。
     """
     file_path = Path(path)
+    if file_path.is_dir():
+        raise IsADirectoryError(
+            f"'{path}' is a directory, not a file. Use list_directory to view its contents."
+        )
     if not file_path.is_file():
         raise FileNotFoundError(f"File not found: {path}")
     try:

--- a/tests/unit/engine/test_tools.py
+++ b/tests/unit/engine/test_tools.py
@@ -324,9 +324,9 @@ class TestReadFile:
         with pytest.raises(FileNotFoundError):
             read_file("/nonexistent/file.txt")
 
-    def test_directory_path_raises_error(self, tmp_path: Path) -> None:
-        """ディレクトリパスで FileNotFoundError を送出する（S-7）。"""
-        with pytest.raises(FileNotFoundError):
+    def test_directory_path_raises_is_a_directory_error(self, tmp_path: Path) -> None:
+        """ディレクトリパスで IsADirectoryError を送出する（#282）。"""
+        with pytest.raises(IsADirectoryError, match="list_directory"):
             read_file(str(tmp_path))
 
     def test_binary_file_raises_value_error(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Added explicit check for directory paths in `read_file()` to raise `IsADirectoryError` instead of `FileNotFoundError`
- Updated docstring to document the new exception type
- Updated test to verify the correct exception type with helpful error message

Closes #282

## Test plan
- [x] Test passes: `test_directory_path_raises_is_a_directory_error` verifies `IsADirectoryError` is raised when a directory is passed
- [x] Error message guides users to use `list_directory` for viewing directory contents
- [x] All quality checks passed (ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)