### PR TITLE
fix(#283): Update configuration documentation

### DIFF
--- a/docs/_examples/config.toml
+++ b/docs/_examples/config.toml
@@ -1,7 +1,7 @@
 # Execution settings
 model = "claudecode:claude-opus-4-6"  # Specify provider with prefix
 timeout = 600
-max_turns = 20
+max_turns = 30
 parallel = true
 base_branch = "main"
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -54,7 +54,7 @@ Complete list of all configuration items.
 |------|------|---------|------------|-------------|
 | `model` | `str` | `"claudecode:claude-opus-4-6"` | Non-empty, prefix required | LLM model name (specify provider with `claudecode:` or `anthropic:` prefix) |
 | `timeout` | `int` | `600` | Positive value | Agent timeout (seconds) |
-| `max_turns` | `int` | `20` | Positive value | Maximum number of agent turns |
+| `max_turns` | `int` | `30` | Positive value | Maximum number of agent turns |
 | `parallel` | `bool` | `true` | - | Enable parallel execution |
 | `base_branch` | `str` | `"main"` | Non-empty | Base branch for diff mode |
 | `output_format` | `str` | `"markdown"` | `"markdown"` or `"json"` | Output format |
@@ -76,6 +76,7 @@ When `model`, `timeout`, or `max_turns` is `None`, the selector definition value
 | `timeout` | `int \| None` | `None` | Positive value | Timeout (seconds) |
 | `max_turns` | `int \| None` | `None` | Positive value | Maximum turns |
 | `referenced_content_max_chars` | `int` | `5000` | Positive value | Maximum characters per referenced_content item. Truncated content gets a truncation marker appended |
+| `convention_files` | `tuple[str, ...]` | `("CLAUDE.md", ".hachimoku/config.toml")` | Each element non-empty | File paths to include as convention context for the selector agent |
 
 ### AggregationConfig
 
@@ -136,7 +137,7 @@ save_reviews = false
 Can also be controlled via CLI options.
 
 ```{code-block} bash
-8moku review --no-save-reviews
+8moku --no-save-reviews
 ```
 
 ## Project Root Discovery

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -54,7 +54,7 @@ parallel = false
 |-----|---|----------|------|------|
 | `model` | `str` | `"claudecode:claude-opus-4-6"` | 空文字不可、プレフィックス必須 | 使用する LLM モデル名（`claudecode:` or `anthropic:` プレフィックスでプロバイダーを指定） |
 | `timeout` | `int` | `600` | 正の値 | エージェントのタイムアウト（秒） |
-| `max_turns` | `int` | `20` | 正の値 | エージェントの最大ターン数 |
+| `max_turns` | `int` | `30` | 正の値 | エージェントの最大ターン数 |
 | `parallel` | `bool` | `true` | - | 並列実行の有効化 |
 | `base_branch` | `str` | `"main"` | 空文字不可 | diff モードの基準ブランチ |
 | `output_format` | `str` | `"markdown"` | `"markdown"` or `"json"` | 出力形式 |
@@ -76,6 +76,7 @@ parallel = false
 | `timeout` | `int \| None` | `None` | 正の値 | タイムアウト（秒） |
 | `max_turns` | `int \| None` | `None` | 正の値 | 最大ターン数 |
 | `referenced_content_max_chars` | `int` | `5000` | 正の値 | referenced_content の各コンテンツの最大文字数。超過時は末尾切り詰め + truncation マーカー追加 |
+| `convention_files` | `tuple[str, ...]` | `("CLAUDE.md", ".hachimoku/config.toml")` | 各要素空文字不可 | セレクターエージェントのコンベンションコンテキストとして含めるファイルパス |
 
 ### AggregationConfig
 
@@ -136,7 +137,7 @@ save_reviews = false
 CLI オプションでも制御できます。
 
 ```{code-block} bash
-8moku review --no-save-reviews
+8moku --no-save-reviews
 ```
 
 ## プロジェクトルート探索


### PR DESCRIPTION
## Summary
- Updates max_turns default value from 20 to 30 in configuration example and documentation tables
- Adds documentation for the convention_files field in SelectorConfig
- Fixes CLI command example (removes incorrect "review" subcommand)
- Ensures consistency across example configuration, English, and Japanese documentation files

Closes #283

## Test plan
- [x] All modified files are documentation files (no code changes)
- [x] Changes reflect current defaults and configuration schema
- [x] Both English and Japanese documentation updated consistently
- [x] Example configuration file reflects actual defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)