### PR TITLE
feat(#296): Add Turn Budget Strategy to code-simplifier prompt

### DIFF
--- a/src/hachimoku/agents/_builtin/code-simplifier.toml
+++ b/src/hachimoku/agents/_builtin/code-simplifier.toml
@@ -24,6 +24,14 @@ When the diff adds a new branch or conditional path, verify the condition can ac
 Only flag dead code when you have confirmed zero usage across the project. If a TODO or docstring claims future use, still report it as a Nitpick with the stated intent so the team can track it.
 If you cannot complete the investigation due to tool call limits, list the files or callers you were unable to verify in your output.
 
+## Turn Budget Strategy
+You have a limited number of tool calls available. Exceeding this limit terminates your execution and discards all findings. Producing a complete result with partial investigation is always better than exhaustive investigation with no result.
+Follow these rules to manage your budget:
+1. Quick scan phase: Start with run_git(["diff"]) and read_file(path) for changed files only. Do not use run_git(["ls-files"]) or read unrelated files until you have assessed the diff.
+2. Scope your investigation: Limit cross-file verification (call-site tracing, usage confirmation) to at most 5 read_file calls beyond the changed files. If more files need checking, list the unverified files in your output instead of reading them.
+3. Documentation-only changes: When the diff contains only documentation files (.md, .rst, .txt, .adoc), skip call-site verification entirely. Focus on content clarity, redundancy, structural simplification, and accuracy.
+4. Output priority: After your investigation, you must produce your structured output. Never spend your remaining budget on additional verification at the expense of producing a result.
+
 ## Priority Criteria
 - Critical: Extreme complexity making code unmaintainable or error-prone.
 - Important: Significant duplication, unnecessary abstraction layers, or convoluted logic.


### PR DESCRIPTION
## Summary
Add Turn Budget Strategy guidance section to the code-simplifier agent's system prompt. This helps the agent manage its limited tool call budget by emphasizing quick scanning, scoped investigation, documentation-only optimization, and output priority.

Closes #296

## Test plan
- [x] Quality checks passed (1949 tests, ruff/mypy clean)
- [x] Manual verification: Turn Budget Strategy section added to both builtin and user agent configs
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)