### PR TITLE
fix(#300): Fix selector FileNotFoundError on non-matching spec paths

### DIFF
--- a/src/hachimoku/agents/_builtin/selector.toml
+++ b/src/hachimoku/agents/_builtin/selector.toml
@@ -42,12 +42,12 @@ List project conventions relevant to this review. Check CLAUDE.md, .hachimoku/co
 If an issue number is provided and issue context is NOT already available in the pre-fetched data (check the user message for '## Pre-fetched Context > ### Issue Context'), use the run_gh tool to fetch the issue details. If issue context has been pre-fetched, summarize it directly from the provided data. Include relevant requirements, acceptance criteria, and discussion points that help review agents understand the broader context.
 
 ### referenced_content
-When the diff or associated context mentions external references (Issue numbers like "#152", file paths like "src/foo.py", spec paths like "specs/005/spec.md", or quoted passages attributed to a source), fetch the referenced content and include it in this field. For each reference:
+When the diff or associated context mentions external references (Issue numbers like "#152", file paths like "src/foo.py", or quoted passages attributed to a source), fetch the referenced content and include it in this field. For each reference:
 - Set reference_type to the kind of reference: "issue", "file", "spec", or "other".
 - Set reference_id to the identifier (e.g., "#152", "src/hachimoku/models/_base.py").
 - Set content to the relevant text from the referenced source.
 
-Before fetching, check if the referenced content is already available in the pre-fetched data. Use the run_gh tool to fetch issue bodies, the read_file tool to read files and specs. Only include references you successfully fetched. If a reference cannot be resolved, omit it.
+Before fetching, check if the referenced content is already available in the pre-fetched data. Use the run_gh tool to fetch issue bodies, the read_file tool to read files. **When a reference mentions a path you are not certain exists, use the list_directory tool to verify the actual directory structure before calling read_file.** Only include references you successfully fetched. If a reference cannot be resolved, omit it.
 
 This data enables review agents to verify consistency between the diff text and its referenced sources (e.g., correct quoting, accurate paraphrasing, matching terminology).
 """


### PR DESCRIPTION
## Summary
- Remove hardcoded spec path example from selector's `referenced_content` section
- Prevents FileNotFoundError on projects without the assumed directory structure
- Add `list_directory` verification instruction for uncertain file paths

Closes #300

## Test plan
- Verify 63 existing tests pass
- Confirm selector can be used in projects with different spec path structures
- Manual testing: Run hachimoku review with a project that has no `specs/005/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)