### PR TITLE
fix(#302): Fix CLI options recognition when placed after positional arguments

### DIFF
--- a/src/hachimoku/cli/_app.py
+++ b/src/hachimoku/cli/_app.py
@@ -147,6 +147,9 @@ class _ReviewGroup(TyperGroup):
         for param in self.get_params(ctx):
             if param.name and param.name in opts:
                 value = param.type_cast_value(ctx, opts[param.name])
+                existing = ctx.params.get(param.name)
+                if param.multiple and existing:
+                    value = (*existing, *value)
                 ctx.params[param.name] = value
         return positional
 

--- a/tests/unit/cli/test_app.py
+++ b/tests/unit/cli/test_app.py
@@ -1929,6 +1929,26 @@ class TestOptionsAfterPositionalArgs:
     @patch(PATCH_RUN_REVIEW, new_callable=AsyncMock)
     @patch(PATCH_RESOLVE_FILES)
     @patch(PATCH_RESOLVE_CONFIG)
+    def test_ext_before_and_after_positional_are_merged(
+        self,
+        mock_config: MagicMock,
+        mock_resolve_files: MagicMock,
+        mock_run_review: AsyncMock,
+    ) -> None:
+        """--ext .md src/ --ext .py → 両方の拡張子がマージされる。"""
+        setup_mocks(mock_config, mock_run_review)
+        mock_resolve_files.return_value = (
+            ResolvedFiles(paths=("/abs/src/a.py",)),
+            (),
+        )
+        result = runner.invoke(app, ["--ext", ".md", "src/", "--ext", ".py"])
+        assert result.exit_code == 0
+        overrides = mock_run_review.call_args.kwargs["config_overrides"]
+        assert set(overrides.get("file_extensions", ())) == {".md", ".py"}
+
+    @patch(PATCH_RUN_REVIEW, new_callable=AsyncMock)
+    @patch(PATCH_RESOLVE_FILES)
+    @patch(PATCH_RESOLVE_CONFIG)
     def test_positional_args_not_contaminated_by_options(
         self,
         mock_config: MagicMock,


### PR DESCRIPTION
## Summary
- Fixed Click Group's allow_interspersed_args=False issue that prevented options like `--ext`, `--model`, and `--issue` from being recognized when placed after positional arguments
- Added `_reparse_interspersed_options()` method to `_ReviewGroup` that re-parses args with `allow_interspersed_args=True` to extract and apply interspersed options
- Options are now correctly applied to `ctx.params` without contaminating the positional arguments

## Test plan
- `test_ext_after_positional_is_parsed`: Verify `--ext .md` works after file path
- `test_multiple_ext_after_positional`: Verify multiple `--ext` options work after path
- `test_model_after_positional_is_parsed`: Verify `--model opus` works after file path
- `test_issue_after_positional_file_mode`: Verify `--issue 50` works after file path
- `test_issue_after_positional_pr_mode`: Verify `--issue 50` works after PR number
- `test_positional_args_not_contaminated_by_options`: Ensure positional args don't include option values

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)