### PR TITLE
fix(#303): Improve allowed_tools validation error message for individual tool names

### DIFF
--- a/src/hachimoku/agents/models.py
+++ b/src/hachimoku/agents/models.py
@@ -108,12 +108,22 @@ def _validate_tool_categories(
     """allowed_tools の各値が ToolCategory に存在することを検証する。
 
     AgentDefinition と SelectorDefinition の共通バリデーションロジック。
+    個別ツール名が指定された場合は、所属カテゴリを案内する。
     """
-    from hachimoku.models.tool_category import ToolCategory
+    from hachimoku.models.tool_category import CATEGORY_TOOL_NAMES, ToolCategory
 
     valid_values = {tc.value for tc in ToolCategory}
     for tool in v:
         if tool not in valid_values:
+            # 個別ツール名 → カテゴリの逆引き
+            for category, tool_names in CATEGORY_TOOL_NAMES.items():
+                if tool in tool_names:
+                    msg = (
+                        f"'{tool}' is not a tool category. "
+                        f"Did you mean '{category}'? "
+                        f"({category} includes: {', '.join(sorted(tool_names))})"
+                    )
+                    raise ValueError(msg)
             msg = (
                 f"Invalid tool category: '{tool}'. "
                 f"Valid categories: {sorted(valid_values)}"

--- a/src/hachimoku/models/tool_category.py
+++ b/src/hachimoku/models/tool_category.py
@@ -7,7 +7,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from enum import StrEnum
+from types import MappingProxyType
+from typing import Final
 
 
 class ToolCategory(StrEnum):
@@ -22,3 +25,14 @@ class ToolCategory(StrEnum):
     GH_READ = "gh_read"
     FILE_READ = "file_read"
     WEB_FETCH = "web_fetch"
+
+
+CATEGORY_TOOL_NAMES: Final[Mapping[str, tuple[str, ...]]] = MappingProxyType(
+    {
+        ToolCategory.GIT_READ: ("run_git",),
+        ToolCategory.GH_READ: ("run_gh",),
+        ToolCategory.FILE_READ: ("list_directory", "read_file"),
+        ToolCategory.WEB_FETCH: ("web_fetch_tool",),
+    }
+)
+"""カテゴリに含まれる個別ツール名。バリデーションエラーメッセージでの案内に使用する。"""

--- a/tests/unit/agents/test_models.py
+++ b/tests/unit/agents/test_models.py
@@ -467,6 +467,44 @@ class TestAgentDefinitionConstraints:
                 _valid_agent_data(allowed_tools=["nonexistent"])
             )
 
+    def test_individual_tool_name_suggests_category(self) -> None:
+        """個別ツール名を指定した場合、正しいカテゴリ名を案内するエラーメッセージが表示される。"""
+        with pytest.raises(
+            ValidationError,
+            match=r"'list_directory' is not a tool category\. Did you mean 'file_read'\?",
+        ):
+            AgentDefinition.model_validate(
+                _valid_agent_data(allowed_tools=["list_directory"])
+            )
+
+    def test_individual_tool_name_shows_category_contents(self) -> None:
+        """エラーメッセージにカテゴリに含まれるツール名一覧が表示される。"""
+        with pytest.raises(
+            ValidationError,
+            match=r"file_read includes: list_directory, read_file",
+        ):
+            AgentDefinition.model_validate(
+                _valid_agent_data(allowed_tools=["list_directory"])
+            )
+
+    def test_individual_tool_name_run_git_suggests_git_read(self) -> None:
+        """run_git を指定した場合、git_read カテゴリを案内する。"""
+        with pytest.raises(
+            ValidationError,
+            match=r"'run_git' is not a tool category\. Did you mean 'git_read'\?",
+        ):
+            AgentDefinition.model_validate(_valid_agent_data(allowed_tools=["run_git"]))
+
+    def test_unknown_tool_name_no_suggestion(self) -> None:
+        """完全に不明な名前の場合はカテゴリ候補のみ表示する。"""
+        with pytest.raises(
+            ValidationError,
+            match=r"Invalid tool category: 'totally_unknown'\. Valid categories:",
+        ):
+            AgentDefinition.model_validate(
+                _valid_agent_data(allowed_tools=["totally_unknown"])
+            )
+
     def test_agent_name_pattern_is_exported(self) -> None:
         """AGENT_NAME_PATTERN 定数がエクスポートされている。"""
         assert AGENT_NAME_PATTERN == r"^[a-z0-9-]+$"
@@ -677,6 +715,16 @@ class TestSelectorDefinitionConstraints:
         with pytest.raises(ValidationError, match="allowed_tools"):
             SelectorDefinition.model_validate(
                 _valid_selector_data(allowed_tools=["invalid_tool"])
+            )
+
+    def test_individual_tool_name_suggests_category(self) -> None:
+        """個別ツール名を指定した場合、正しいカテゴリ名を案内するエラーメッセージが表示される。"""
+        with pytest.raises(
+            ValidationError,
+            match=r"'list_directory' is not a tool category\. Did you mean 'file_read'\?",
+        ):
+            SelectorDefinition.model_validate(
+                _valid_selector_data(allowed_tools=["list_directory"])
             )
 
 


### PR DESCRIPTION
## Summary
- Add CATEGORY_TOOL_NAMES mapping to provide helpful suggestions when users specify individual tool names (e.g., 'list_directory') instead of tool categories
- When a tool name is recognized, the error message now suggests the correct category and lists all tools in that category
- Add comprehensive test coverage for individual tool name suggestions in both AgentDefinition and SelectorDefinition

Closes #303

## Test plan
- All validation error tests pass with new individual tool name suggestion messages
- Error message displays correct category name when an individual tool is specified
- Error message shows all tools in the suggested category
- Unknown tool names still display the general category list without suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)