### PR TITLE
fix: Improve FileNotFoundError message to guide LLM agents

### DIFF
--- a/src/hachimoku/engine/_tools/_file.py
+++ b/src/hachimoku/engine/_tools/_file.py
@@ -45,7 +45,10 @@ def read_file(path: str) -> str:
             f"'{path}' is a directory, not a file. Use list_directory to view its contents."
         )
     if not file_path.is_file():
-        raise FileNotFoundError(f"File not found: {path}")
+        raise FileNotFoundError(
+            f"File not found: {path}. "
+            f"Use list_directory to verify which files exist before reading."
+        )
     try:
         return file_path.read_text(encoding="utf-8")
     except UnicodeDecodeError:

--- a/tests/unit/engine/test_tools.py
+++ b/tests/unit/engine/test_tools.py
@@ -321,7 +321,7 @@ class TestReadFile:
 
     def test_nonexistent_file_raises_error(self) -> None:
         """存在しないファイルで FileNotFoundError を送出する。"""
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="list_directory"):
             read_file("/nonexistent/file.txt")
 
     def test_directory_path_raises_is_a_directory_error(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Enhanced error message in `read_file` to help LLM agents understand they should use `list_directory` before retrying when a file is not found
- Updated test to verify the improved error message is present
- Improves agent decision-making and reduces unnecessary retry attempts

## Test plan
- [x] Unit test verifies new error message includes "list_directory" guidance
- [x] ruff check, ruff format, and mypy all passed
- [x] Error message clearly guides agents to use list_directory API

🤖 Generated with [Claude Code](https://claude.com/claude-code)