### PR TITLE
feat: Add three specialized review agents (security, performance, architecture)

### DIFF
--- a/src/hachimoku/agents/_builtin/architecture-reviewer.toml
+++ b/src/hachimoku/agents/_builtin/architecture-reviewer.toml
@@ -90,5 +90,8 @@ content_patterns = [
     "class\\s+\\w+\\(", "def\\s+__init__",
     "@abstractmethod", "@overload",
     "ABC\\)", "Protocol\\)",
-    "from\\s+\\w+\\.\\w+.*\\s+import\\s+"
+    "from\\s+\\w+\\.\\w+.*\\s+import\\s+",
+    "trait\\s+\\w+", "impl\\s+\\w+\\s+for",
+    "dyn\\s+\\w+", "pub\\s+mod\\s+",
+    "interface\\s+\\w+", "extends\\s+\\w+"
 ]

--- a/src/hachimoku/agents/_builtin/performance-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/performance-analyzer.toml
@@ -84,6 +84,9 @@ content_patterns = [
     "\\.fetchall\\(", "\\.fetchone\\(",
     "\\.read\\(", "\\.write\\(", "\\.readlines\\(",
     "sleep\\(", "Lock\\(", "Semaphore\\(",
-    "async\\s+def", "await\\s+",
-    "\\.connect\\(", "\\.close\\("
+    "async\\s+def", "async\\s+fn",
+    "await\\s+", "\\.await",
+    "\\.connect\\(", "\\.close\\(",
+    "spawn", "Mutex", "RwLock",
+    "checkpoint", "batch", "throttle"
 ]

--- a/src/hachimoku/agents/_builtin/security-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/security-analyzer.toml
@@ -85,5 +85,7 @@ content_patterns = [
     "password", "secret", "token", "api_key", "credential",
     "hashlib", "hmac", "encrypt", "decrypt",
     "\\.execute\\(", "query\\(",
-    "urllib", "requests\\."
+    "urllib", "requests\\.",
+    "unsafe\\s", "Command::new", "std::process",
+    "sql!", "raw_sql", "sqlx::query"
 ]


### PR DESCRIPTION
## Summary

This PR introduces three new specialized review agents for hachimoku as defined in Issue #314:

- **security-analyzer**: Detects security vulnerabilities including injection attacks, authentication/authorization flaws, hardcoded credentials, weak cryptography, and OWASP Top 10 issues
- **performance-analyzer**: Identifies performance issues such as algorithmic complexity, memory leaks, I/O inefficiency, and resource leaks
- **architecture-reviewer**: Reviews architecture and design patterns, checking for SOLID violations, layer violations, circular dependencies, and coupling issues

All three agents follow established patterns from the existing codebase and use the `severity_classified` output schema with confidence filtering.

Closes #314

## Test plan

- [x] All three TOML files created in `src/hachimoku/agents/_builtin/`
- [x] Quality checks passed (ruff, mypy)
- [x] Agent definitions follow existing patterns (silent-failure-hunter.toml structure)
- [x] Output schema set to `severity_classified` with confidence filtering
- [x] Content patterns configured for applicability detection
- [x] Manual testing: agents can be loaded and used in hachimoku CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)