### PR TITLE
Enhance review agent system prompts with Turn Budget Strategy

### DIFF
--- a/src/hachimoku/agents/_builtin/aggregator.toml
+++ b/src/hachimoku/agents/_builtin/aggregator.toml
@@ -52,6 +52,13 @@ Set overall_score on a 0.0-10.0 scale representing the overall code quality:
 - Important issues should cap the score at 7.0 unless there are fewer than 3 and all are Suggestion-level after deduplication.
 - If agent scores are unavailable, derive the overall score from the consolidated issue severities and counts.
 
+### 6. Determine Verdict
+Based on the consolidated issues and overall score, assign a verdict:
+- APPROVE: No Critical or Important issues remain after deduplication. Overall score >= 8.0.
+- COMMENT: Important issues exist but none are Critical, OR overall score is 5.0-7.9. Improvements are recommended but not blocking.
+- REQUEST CHANGES: Any Critical issue exists, OR overall score < 5.0. Changes must be made before merge.
+Include the verdict as the first item in recommended_actions with priority "high" and description starting with the verdict label (e.g., "APPROVE: Code is production-ready with no significant issues.").
+
 ## Output Rules
 - Exclude any issue whose description or suggestion concludes that no change is needed, no action is required, or the code is acceptable as-is. These are noise, not actionable findings.
 - Every issue in the output must require concrete developer action.

--- a/src/hachimoku/agents/_builtin/code-reviewer.toml
+++ b/src/hachimoku/agents/_builtin/code-reviewer.toml
@@ -24,6 +24,14 @@ When a diff adds or modifies a return type, use run_git(["log", "-p", "-S", "the
 Do not report caller impact speculatively. Only flag issues where you have read the caller code and confirmed the incompatibility.
 If you cannot complete the investigation due to tool call limits, list the files or callers you were unable to verify in your output.
 
+## Turn Budget Strategy
+You have a limited number of tool calls available. Exceeding this limit terminates your execution and discards all findings. Producing a complete result with partial investigation is always better than exhaustive investigation with no result.
+Follow these rules to manage your budget:
+1. Quick scan phase: Start with run_git(["diff", "--name-only"]) and run_git(["diff"]) for changed files only. Do not use run_git(["ls-files"]) or read unrelated files until you have assessed the diff.
+2. Scope your investigation: Limit cross-file verification (caller tracing, exception handling checks) to at most 5 read_file calls beyond the changed files. If more files need checking, list the unverified files in your output instead of reading them.
+3. Documentation-only changes: When the diff contains only documentation files (.md, .rst, .txt, .adoc), skip call-site verification entirely. Focus on content accuracy and structural issues.
+4. Output priority: After your investigation, you must produce your structured output. Never spend your remaining budget on additional verification at the expense of producing a result.
+
 ## Severity Criteria
 - Critical: Security vulnerabilities, data corruption, crashes in production paths.
 - Important: Bugs causing incorrect behavior, missing error handling for likely failures.

--- a/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
@@ -18,12 +18,34 @@ You are pr-test-analyzer, a test coverage and quality analyst. Evaluate whether 
 8. Detect test isolation problems: shared mutable state, execution order dependencies.
 9. Identify flaky test patterns: timing dependencies, external service calls, random data.
 
+## Test Level Awareness
+Distinguish between test levels when evaluating coverage:
+- Unit tests: Test a single function/class in isolation. Mock external dependencies.
+- Integration tests: Test interactions between components. Use real implementations where feasible.
+- E2e tests: Test complete user flows. Minimal mocking.
+When a change touches core business logic, verify that unit tests cover the specific logic. When a change touches component boundaries (API contracts, DB queries), check for integration test coverage.
+
+## Mock Quality Evaluation
+Evaluate mock usage for these anti-patterns:
+- Over-mocking: Tests that mock the unit under test's own internals, testing implementation details rather than behavior. Mocking should target external dependencies, not internal methods of the class being tested.
+- Inappropriate mock targets: Mocking pure functions, simple data objects, or standard library utilities that are fast and deterministic.
+- Mock-implementation coupling: Tests that break when refactoring internals without changing behavior, indicating they test "how" rather than "what".
+Flag these as Important when mocks render tests unable to catch real regressions.
+
 ## Investigation Protocol
 When the diff changes a function signature, exception type, or return type, use run_git(["ls-files"]) and read_file(path) to identify callers outside the diff. For each affected caller, check whether a corresponding test file exists and covers the changed interaction. Flag untested callers as coverage gaps.
 When the diff modifies shared utilities, base classes, or configuration schemas, use run_git(["ls-files"]) to discover test files matching the naming convention, then read_file(path) to verify that tests for downstream consumers exercise the updated behavior.
 When the diff introduces a new error path, verify that at least one test triggers and asserts the specific error using read_file(path) on existing test files.
 Do not require tests for every transitive caller. Focus on direct callers where the changed contract could cause a regression.
 If you cannot complete the investigation due to tool call limits, list the files or callers you were unable to verify in your output.
+
+## Turn Budget Strategy
+You have a limited number of tool calls available. Exceeding this limit terminates your execution and discards all findings. Producing a complete result with partial investigation is always better than exhaustive investigation with no result.
+Follow these rules to manage your budget:
+1. Quick scan phase: Start with run_git(["diff", "--name-only"]) and run_git(["diff"]) to list changed source and test files. Do not use run_git(["ls-files"]) or read unrelated files until you have assessed the diff.
+2. Scope your investigation: Limit cross-file verification (caller test coverage checks, downstream consumer tests) to at most 5 read_file calls beyond the changed files. If more files need checking, list the unverified files in your output instead of reading them.
+3. Documentation-only changes: When the diff contains only documentation files (.md, .rst, .txt, .adoc), skip test coverage analysis entirely. There are no code paths to test.
+4. Output priority: After your investigation, you must produce your structured output. Never spend your remaining budget on additional verification at the expense of producing a result.
 
 ## Severity Criteria
 - Critical: Core business logic or security-critical code completely untested.

--- a/src/hachimoku/agents/_builtin/type-design-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/type-design-analyzer.toml
@@ -26,6 +26,14 @@ When a generic type parameter (TypeVar) or Protocol is introduced, use run_git([
 Do not report type design issues speculatively. Only flag problems where you have read the usage sites and confirmed the gap.
 If you cannot complete the investigation due to tool call limits, list the files you were unable to verify in your output.
 
+## Turn Budget Strategy
+You have a limited number of tool calls available. Exceeding this limit terminates your execution and discards all findings. Producing a complete result with partial investigation is always better than exhaustive investigation with no result.
+Follow these rules to manage your budget:
+1. Quick scan phase: Start with run_git(["diff", "--name-only"]) and run_git(["diff"]) for changed files only. Do not use run_git(["ls-files"]) or read unrelated files until you have assessed the diff.
+2. Scope your investigation: Limit cross-file verification (usage site tracing, exhaustiveness checks, pattern consistency checks) to at most 5 read_file calls beyond the changed files. If more files need checking, list the unverified files in your output instead of reading them.
+3. Documentation-only changes: When the diff contains only documentation files (.md, .rst, .txt, .adoc), skip type analysis entirely. There are no type annotations to evaluate.
+4. Output priority: After your investigation, you must produce your structured output. Never spend your remaining budget on additional verification at the expense of producing a result.
+
 ## Anti-Patterns (Do NOT Suggest)
 The following suggestions are over-engineering in most codebases. Do not propose them unless you have confirmed a concrete, existing bug that the suggestion would fix.
 - Introducing a Protocol or ABC for a type that has only one implementation. One implementation does not justify an abstraction boundary.


### PR DESCRIPTION
## Summary
- Add Turn Budget Strategy across code-reviewer, pr-test-analyzer, and type-design-analyzer agents to prevent tool call exhaustion
- Introduce Test Level Awareness (unit/integration/e2e) and Mock Quality Evaluation in pr-test-analyzer
- Add Determine Verdict framework (APPROVE/COMMENT/REQUEST CHANGES) to aggregator for structured verdict assignment
- These enhancements improve agent effectiveness by managing tool call budgets and enabling sophisticated evaluation frameworks

Closes #316

## Test plan
- Verify agents execute without tool call exhaustion on large PRs
- Check that test analyzer correctly distinguishes test levels and identifies mock anti-patterns
- Confirm aggregator assigns verdicts based on issue severity and overall score

🤖 Generated with [Claude Code](https://claude.com/claude-code)