### PR TITLE
Enhance agent verification gates with evidence confirmation and YAGNI checks

### DIFF
--- a/src/hachimoku/agents/_builtin/architecture-reviewer.toml
+++ b/src/hachimoku/agents/_builtin/architecture-reviewer.toml
@@ -70,6 +70,9 @@ The confidence score is for your internal reasoning only — do not include it i
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code restructuring, module reorganization, or dependency correction.
 - If you investigate a potential concern but determine it is acceptable in context (e.g., a pragmatic trade-off documented in comments), omit it entirely from your output.
+- Before reporting any finding, confirm you have used read_file to read the relevant code and verified the issue exists. Do not report issues based on assumptions about code you have not read.
+- Do not use uncertain language in suggestions: "should", "probably", "seems to", "might", "could potentially". State only confirmed facts. If you are not certain, do not report the finding.
+- Do not report issues that only "might become a problem in the future" or "could cause issues at scale". Only report issues where the problem is present now and demonstrably affects the current code.
 
 ## Scoring Guidelines
 Set overall_score on a 0.0-10.0 scale:

--- a/src/hachimoku/agents/_builtin/breaking-change-detector.toml
+++ b/src/hachimoku/agents/_builtin/breaking-change-detector.toml
@@ -102,6 +102,9 @@ The confidence score is for your internal reasoning only — do not include it i
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, migration guide, deprecation notice, or other concrete developer action.
 - If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+- Before reporting any finding, confirm you have used read_file to read the relevant code and verified the issue exists. Do not report issues based on assumptions about code you have not read.
+- Do not use uncertain language in suggestions: "should", "probably", "seems to", "might", "could potentially". State only confirmed facts. If you are not certain, do not report the finding.
+- Do not report issues that only "might become a problem in the future" or "could cause issues at scale". Only report issues where the problem is present now and demonstrably affects the current code.
 - Do NOT flag changes to private/internal APIs (names starting with underscore) unless they are re-exported publicly.
 - Do NOT flag additive-only changes (new optional parameters with defaults, new public functions) as breaking.
 

--- a/src/hachimoku/agents/_builtin/code-reviewer.toml
+++ b/src/hachimoku/agents/_builtin/code-reviewer.toml
@@ -75,6 +75,9 @@ The confidence score is for your internal reasoning only — do not include it i
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
 - If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+- Before reporting any finding, confirm you have used read_file to read the relevant code and verified the issue exists. Do not report issues based on assumptions about code you have not read.
+- Do not use uncertain language in suggestions: "should", "probably", "seems to", "might", "could potentially". State only confirmed facts. If you are not certain, do not report the finding.
+- Do not report issues that only "might become a problem in the future" or "could cause issues at scale". Only report issues where the problem is present now and demonstrably affects the current code.
 
 ## Quality Principles
 - Only report issues you are confident about. Omit uncertain findings.

--- a/src/hachimoku/agents/_builtin/code-simplifier.toml
+++ b/src/hachimoku/agents/_builtin/code-simplifier.toml
@@ -77,6 +77,9 @@ The confidence score is for your internal reasoning only — do not include it i
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
 - If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+- Before reporting any finding, confirm you have used read_file to read the relevant code and verified the issue exists. Do not report issues based on assumptions about code you have not read.
+- Do not use uncertain language in suggestions: "should", "probably", "seems to", "might", "could potentially". State only confirmed facts. If you are not certain, do not report the finding.
+- Do not report issues that only "might become a problem in the future" or "could cause issues at scale". Only report issues where the problem is present now and demonstrably affects the current code.
 
 ## Scoring Guidelines
 Set overall_score on a 0.0-10.0 scale:

--- a/src/hachimoku/agents/_builtin/comment-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/comment-analyzer.toml
@@ -70,6 +70,9 @@ The confidence score is for your internal reasoning only — do not include it i
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
 - If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+- Before reporting any finding, confirm you have used read_file to read the relevant code and verified the issue exists. Do not report issues based on assumptions about code you have not read.
+- Do not use uncertain language in suggestions: "should", "probably", "seems to", "might", "could potentially". State only confirmed facts. If you are not certain, do not report the finding.
+- Do not report issues that only "might become a problem in the future" or "could cause issues at scale". Only report issues where the problem is present now and demonstrably affects the current code.
 
 ## Scoring Guidelines
 Set overall_score on a 0.0-10.0 scale:

--- a/src/hachimoku/agents/_builtin/dependency-auditor.toml
+++ b/src/hachimoku/agents/_builtin/dependency-auditor.toml
@@ -82,6 +82,9 @@ The confidence score is for your internal reasoning only — do not include it i
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a dependency change, version pin update, license review, or other concrete developer action.
 - If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+- Before reporting any finding, confirm you have used read_file to read the relevant code and verified the issue exists. Do not report issues based on assumptions about code you have not read.
+- Do not use uncertain language in suggestions: "should", "probably", "seems to", "might", "could potentially". State only confirmed facts. If you are not certain, do not report the finding.
+- Do not report issues that only "might become a problem in the future" or "could cause issues at scale". Only report issues where the problem is present now and demonstrably affects the current code.
 
 ## Scoring Guidelines
 Set overall_score on a 0.0-10.0 scale:

--- a/src/hachimoku/agents/_builtin/performance-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/performance-analyzer.toml
@@ -63,6 +63,9 @@ The confidence score is for your internal reasoning only — do not include it i
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change or architectural adjustment.
 - If you investigate a potential concern but determine it is acceptable in context (e.g., the data set is inherently small), omit it entirely from your output.
+- Before reporting any finding, confirm you have used read_file to read the relevant code and verified the issue exists. Do not report issues based on assumptions about code you have not read.
+- Do not use uncertain language in suggestions: "should", "probably", "seems to", "might", "could potentially". State only confirmed facts. If you are not certain, do not report the finding.
+- Do not report issues that only "might become a problem in the future" or "could cause issues at scale". Only report issues where the problem is present now and demonstrably affects the current code.
 
 ## Scoring Guidelines
 Set overall_score on a 0.0-10.0 scale:

--- a/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/pr-test-analyzer.toml
@@ -91,6 +91,9 @@ The confidence score is for your internal reasoning only — do not include it i
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
 - If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+- Before reporting any finding, confirm you have used read_file to read the relevant code and verified the issue exists. Do not report issues based on assumptions about code you have not read.
+- Do not use uncertain language in suggestions: "should", "probably", "seems to", "might", "could potentially". State only confirmed facts. If you are not certain, do not report the finding.
+- Do not report issues that only "might become a problem in the future" or "could cause issues at scale". Only report issues where the problem is present now and demonstrably affects the current code.
 
 ## Scoring Guidelines
 Set overall_score on a 0.0-10.0 scale:

--- a/src/hachimoku/agents/_builtin/security-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/security-analyzer.toml
@@ -79,6 +79,9 @@ The confidence score is for your internal reasoning only — do not include it i
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, configuration fix, or other concrete developer action.
 - If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+- Before reporting any finding, confirm you have used read_file to read the relevant code and verified the issue exists. Do not report issues based on assumptions about code you have not read.
+- Do not use uncertain language in suggestions: "should", "probably", "seems to", "might", "could potentially". State only confirmed facts. If you are not certain, do not report the finding.
+- Do not report issues that only "might become a problem in the future" or "could cause issues at scale". Only report issues where the problem is present now and demonstrably affects the current code.
 
 ## Scoring Guidelines
 Set overall_score on a 0.0-10.0 scale:

--- a/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
+++ b/src/hachimoku/agents/_builtin/silent-failure-hunter.toml
@@ -63,6 +63,9 @@ The confidence score is for your internal reasoning only — do not include it i
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
 - If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+- Before reporting any finding, confirm you have used read_file to read the relevant code and verified the issue exists. Do not report issues based on assumptions about code you have not read.
+- Do not use uncertain language in suggestions: "should", "probably", "seems to", "might", "could potentially". State only confirmed facts. If you are not certain, do not report the finding.
+- Do not report issues that only "might become a problem in the future" or "could cause issues at scale". Only report issues where the problem is present now and demonstrably affects the current code.
 
 ## Scoring Guidelines
 Set overall_score on a 0.0-10.0 scale:

--- a/src/hachimoku/agents/_builtin/type-design-analyzer.toml
+++ b/src/hachimoku/agents/_builtin/type-design-analyzer.toml
@@ -88,6 +88,9 @@ The confidence score is for your internal reasoning only — do not include it i
 - Do NOT report an issue if your own analysis concludes that no change is needed, the current code is acceptable as-is, or no action is required.
 - Every reported issue must be actionable — it must clearly require a code change, documentation fix, or other concrete developer action.
 - If you investigate a potential concern but determine it is acceptable in context, omit it entirely from your output.
+- Before reporting any finding, confirm you have used read_file to read the relevant code and verified the issue exists. Do not report issues based on assumptions about code you have not read.
+- Do not use uncertain language in suggestions: "should", "probably", "seems to", "might", "could potentially". State only confirmed facts. If you are not certain, do not report the finding.
+- Do not report issues that only "might become a problem in the future" or "could cause issues at scale". Only report issues where the problem is present now and demonstrably affects the current code.
 
 ## Quality Principles
 - Prioritize how existing types are used over proposing new types. Misuse of an existing type is a higher-priority finding than a missing abstraction.

--- a/tests/unit/agents/test_loader.py
+++ b/tests/unit/agents/test_loader.py
@@ -76,6 +76,20 @@ def _write_toml(tmp_path: Path, filename: str, content: str) -> Path:
     return toml_path
 
 
+def _get_self_filtering_section(system_prompt: str) -> str:
+    """system_prompt から Self-Filtering Rules セクションを抽出する。"""
+    marker = "## Self-Filtering Rules"
+    start = system_prompt.find(marker)
+    if start == -1:
+        return ""
+    section = system_prompt[start:]
+    # 次の ## セクションまたは末尾まで
+    next_section = section.find("\n## ", len(marker))
+    if next_section != -1:
+        section = section[:next_section]
+    return section
+
+
 def _find_agent(agents: tuple[AgentDefinition, ...], name: str) -> AgentDefinition:
     """名前でエージェントを検索する。見つからなければ AssertionError。"""
     for agent in agents:
@@ -684,6 +698,60 @@ class TestBuiltinAgentSystemPromptStructure:
         agent = _find_agent(builtin_agents, agent_name)
         assert "## Confidence Filtering" in agent.system_prompt, (
             f"{agent_name}: system_prompt does not contain Confidence Filtering section"
+        )
+
+    @pytest.mark.parametrize(
+        "agent_name",
+        sorted(BUILTIN_AGENT_NAMES),
+    )
+    def test_system_prompt_contains_evidence_verification_gate(
+        self,
+        builtin_agents: tuple[AgentDefinition, ...],
+        agent_name: str,
+    ) -> None:
+        """system_prompt の Self-Filtering Rules に証拠確認ゲートを含む。"""
+        filtering_section = _get_self_filtering_section(
+            _find_agent(builtin_agents, agent_name).system_prompt
+        )
+        assert "read_file" in filtering_section, (
+            f"{agent_name}: Self-Filtering Rules does not contain evidence "
+            f"verification gate (must reference read_file)"
+        )
+
+    @pytest.mark.parametrize(
+        "agent_name",
+        sorted(BUILTIN_AGENT_NAMES),
+    )
+    def test_system_prompt_contains_red_flag_language_prohibition(
+        self,
+        builtin_agents: tuple[AgentDefinition, ...],
+        agent_name: str,
+    ) -> None:
+        """system_prompt の Self-Filtering Rules に Red Flag 言語の禁止を含む。"""
+        filtering_section = _get_self_filtering_section(
+            _find_agent(builtin_agents, agent_name).system_prompt
+        )
+        for keyword in ("should", "probably", "might"):
+            assert keyword in filtering_section.lower(), (
+                f"{agent_name}: Self-Filtering Rules does not prohibit "
+                f"red flag language (missing '{keyword}')"
+            )
+
+    @pytest.mark.parametrize(
+        "agent_name",
+        sorted(BUILTIN_AGENT_NAMES),
+    )
+    def test_system_prompt_contains_yagni_check(
+        self,
+        builtin_agents: tuple[AgentDefinition, ...],
+        agent_name: str,
+    ) -> None:
+        """system_prompt の Self-Filtering Rules に YAGNI チェックを含む。"""
+        filtering_section = _get_self_filtering_section(
+            _find_agent(builtin_agents, agent_name).system_prompt
+        )
+        assert "future" in filtering_section.lower(), (
+            f"{agent_name}: Self-Filtering Rules does not contain YAGNI check"
         )
 
 


### PR DESCRIPTION
## 概要

全ビルトインエージェントの self-filtering ルールを3つの重要なゲートで強化します：

1. **証拠確認ゲート**: 報告前に `read_file` で検証を確認
2. **Red Flag 言語禁止**: 不確定な表現（should, might, probably）を排除
3. **YAGNI チェック**: 現在のコード以外の見込み問題は報告しない

これらのルールを全エージェント定義に一括適用し、対応するテストを追加しました。

Closes #324

## テストプラン

- `test_system_prompt_contains_evidence_verification_gate`: 全エージェントが read_file 参照を含むか検証
- `test_system_prompt_contains_red_flag_language_prohibition`: Red Flag 言語の禁止ルールを確認
- `test_system_prompt_contains_yagni_check`: YAGNI チェック（future キーワード）の存在確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)