### PR TITLE
refactor: Migrate to public pydantic-ai toolsets API

### DIFF
--- a/src/hachimoku/engine/_runner.py
+++ b/src/hachimoku/engine/_runner.py
@@ -74,8 +74,7 @@ async def run_agent(context: AgentExecutionContext) -> AgentResult:
         if isinstance(resolved, ClaudeCodeModel):
             # mypy が FunctionToolset.tools の dict[str, Tool[Any]] を
             # AgentToolset.tools の dict[str, PydanticAITool] と互換とみなせないため。
-            # set_agent_toolsets の docstring が agent._function_toolset を使用例として記載。
-            resolved.set_agent_toolsets(agent._function_toolset)  # type: ignore[arg-type]
+            resolved.set_agent_toolsets(agent.toolsets[0])  # type: ignore[arg-type]
 
         result = await run_agent_safe(
             agent,

--- a/src/hachimoku/engine/_selector.py
+++ b/src/hachimoku/engine/_selector.py
@@ -258,8 +258,7 @@ async def run_selector(
         if isinstance(resolved, ClaudeCodeModel):
             # mypy が FunctionToolset.tools の dict[str, Tool[Any]] を
             # AgentToolset.tools の dict[str, PydanticAITool] と互換とみなせないため。
-            # set_agent_toolsets の docstring が agent._function_toolset を使用例として記載。
-            resolved.set_agent_toolsets(agent._function_toolset)  # type: ignore[arg-type]
+            resolved.set_agent_toolsets(agent.toolsets[0])  # type: ignore[arg-type]
 
         result = await run_agent_safe(
             agent,

--- a/tests/unit/engine/test_runner.py
+++ b/tests/unit/engine/test_runner.py
@@ -384,9 +384,7 @@ class TestRunAgentResolveModel:
         ctx = _make_context()
         await run_agent(ctx)
 
-        mock_model.set_agent_toolsets.assert_called_once_with(
-            mock_instance._function_toolset
-        )
+        mock_model.set_agent_toolsets.assert_called_once_with(mock_instance.toolsets[0])
 
     @patch("hachimoku.engine._runner.run_agent_safe")
     @patch("hachimoku.engine._runner.resolve_model", side_effect=lambda m, **_kw: m)

--- a/tests/unit/engine/test_selector.py
+++ b/tests/unit/engine/test_selector.py
@@ -801,9 +801,7 @@ class TestRunSelectorResolveModel:
             resolved_content="test diff content",
         )
 
-        mock_model.set_agent_toolsets.assert_called_once_with(
-            mock_instance._function_toolset
-        )
+        mock_model.set_agent_toolsets.assert_called_once_with(mock_instance.toolsets[0])
 
     @patch("hachimoku.engine._selector.resolve_model", side_effect=_PASSTHROUGH_RESOLVE)
     @patch("hachimoku.engine._selector.run_agent_safe")


### PR DESCRIPTION
## Summary
- Migrate from internal pydantic-ai API `agent._function_toolset` to public API `agent.toolsets[0]`
- Removes dependency on internal implementation details
- Ensures compatibility with future pydantic-ai versions

Closes #332

## Test plan
- All existing unit tests pass (test_runner.py, test_selector.py)
- Quality checks complete: ruff check, ruff format, mypy

🤖 Generated with [Claude Code](https://claude.com/claude-code)